### PR TITLE
Removes total hits counter metric

### DIFF
--- a/pkg/threescale/metrics/prometheus.go
+++ b/pkg/threescale/metrics/prometheus.go
@@ -84,13 +84,6 @@ var (
 		[]string{"backendURL", "serviceID", "code"},
 	)
 
-	totalRequests = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "handle_authorization_requests",
-			Help: "Total number of requests to adapter",
-		},
-	)
-
 	cacheHits = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "system_cache_hits",
@@ -171,13 +164,6 @@ func (r *Reporter) ReportStatus(serviceID string, s StatusReport) error {
 	return nil
 }
 
-// IncrementTotalRequests increments the request count for authorization handler
-func (r *Reporter) IncrementTotalRequests() {
-	if r != nil && r.shouldReport {
-		totalRequests.Inc()
-	}
-}
-
 // IncrementCacheHits increments proxy configurations that have been read from the cache
 func (r *Reporter) IncrementCacheHits() {
 	if r != nil && r.shouldReport {
@@ -190,7 +176,7 @@ func (r *Reporter) Serve() {
 	if r.serveOnPort == 0 {
 		r.serveOnPort = defaultMetricsPort
 	}
-	prometheus.MustRegister(systemLatency, backendLatency, totalRequests, cacheHits)
+	prometheus.MustRegister(systemLatency, backendLatency, cacheHits)
 	http.Handle("/metrics", promhttp.Handler())
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", r.serveOnPort))
 	if err != nil {

--- a/pkg/threescale/metrics/prometheus.go
+++ b/pkg/threescale/metrics/prometheus.go
@@ -78,7 +78,7 @@ var (
 
 	backendStatusCodes = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "backend_http_status",
+			Name: "threescale_backend_http_status",
 			Help: "HTTP Status response codes for requests to 3scale backend",
 		},
 		[]string{"backendURL", "serviceID", "code"},
@@ -86,7 +86,7 @@ var (
 
 	cacheHits = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "system_cache_hits",
+			Name: "threescale_system_cache_hits",
 			Help: "Total number of requests to 3scale system fetched from cache",
 		},
 	)

--- a/pkg/threescale/metrics/prometheus_test.go
+++ b/pkg/threescale/metrics/prometheus_test.go
@@ -92,14 +92,14 @@ func TestReportStatus(t *testing.T) {
 	}{
 		{
 			name:       "Test invalid status code",
-			metricName: "backend_http_status",
+			metricName: "threescale_backend_http_status",
 			expect:     ``,
 			expectErr:  true,
 			collector:  backendStatusCodes,
 		},
 		{
 			name:       "Test Report unsupported target",
-			metricName: "backend_http_status",
+			metricName: "threescale_backend_http_status",
 			expect:     ``,
 			collector:  backendStatusCodes,
 			expectErr:  true,
@@ -108,11 +108,11 @@ func TestReportStatus(t *testing.T) {
 		},
 		{
 			name:       "Test Report Backend HTTP Status",
-			metricName: "backend_http_status",
+			metricName: "threescale_backend_http_status",
 			expect: `
-		               # HELP backend_http_status HTTP Status response codes for requests to 3scale backend
-		               # TYPE backend_http_status counter
-		               backend_http_status{backendURL="www.fake.com",code="200",serviceID="123"} 1
+			       # HELP threescale_backend_http_status HTTP Status response codes for requests to 3scale backend
+			       # TYPE threescale_backend_http_status counter
+			       threescale_backend_http_status{backendURL="www.fake.com",code="200",serviceID="123"} 1
 		       `,
 			collector: backendStatusCodes,
 			code:      http.StatusOK,

--- a/pkg/threescale/metrics/prometheus_test.go
+++ b/pkg/threescale/metrics/prometheus_test.go
@@ -37,11 +37,10 @@ func TestObserveSystemLatency(t *testing.T) {
 	r := NewMetricsReporter(true, 8080)
 	l := NewLatencyReport("", time.Second+time.Millisecond, url, System)
 	r.ObserveLatency(serviceID, l)
-	// TODO - Uncomment when https://github.com/prometheus/client_golang/issues/498 is resolved
-	//err := testutil.CollectAndCompare(systemLatency, strings.NewReader(expect), metricName)
-	//if err != nil {
-	//	t.Fatalf(err.Error())
-	//}
+	err := testutil.CollectAndCompare(systemLatency, strings.NewReader(expect), metricName)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 }
 
 func TestObserveBackendLatency(t *testing.T) {
@@ -49,20 +48,20 @@ func TestObserveBackendLatency(t *testing.T) {
 	const expect = `
 		# HELP threescale_backend_latency Request latency for requests to 3scale backend
 		# TYPE threescale_backend_latency histogram
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.01"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.02"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.03"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.05"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.08"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.1"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.15"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.2"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.3"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="0.5"} 0
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="1"} 1
-		threescale_backend_latency_bucket{backendURL="www.fake.com",serviceID="123",le="+Inf"} 1
-		threescale_backend_latency_sum{backendURL="www.fake.com",serviceID="123"} 1
-		threescale_backend_latency_count{backendURL="www.fake.com",serviceID="123"} 1
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.01"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.02"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.03"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.05"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.08"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.1"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.15"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.2"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.3"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="0.5"} 0
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="1"} 1
+		threescale_backend_latency_bucket{backendURL="www.fake.com",endpoint="Authorise",serviceID="123",le="+Inf"} 1
+		threescale_backend_latency_sum{backendURL="www.fake.com",endpoint="Authorise",serviceID="123"} 1
+		threescale_backend_latency_count{backendURL="www.fake.com",endpoint="Authorise",serviceID="123"} 1
 
 	`
 	r := NewMetricsReporter(true, 8080)
@@ -73,11 +72,10 @@ func TestObserveBackendLatency(t *testing.T) {
 		Target:    Backend,
 	}
 	r.ObserveLatency(serviceID, l)
-	// TODO - Uncomment when https://github.com/prometheus/client_golang/issues/498 is resolved
-	//err := testutil.CollectAndCompare(backendLatency, strings.NewReader(expect), metricName)
-	//if err != nil {
-	//	t.Fatalf(err.Error())
-	//}
+	err := testutil.CollectAndCompare(backendLatency, strings.NewReader(expect), metricName)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
 }
 
 func TestReportStatus(t *testing.T) {

--- a/pkg/threescale/metrics/prometheus_test.go
+++ b/pkg/threescale/metrics/prometheus_test.go
@@ -150,19 +150,6 @@ func TestReportStatus(t *testing.T) {
 	}
 }
 
-func TestIncrementTotalRequests(t *testing.T) {
-	collector := totalRequests
-	if testutil.ToFloat64(collector) != 0 {
-		t.Fatalf("unexpected counter value for %s", collector.Desc().String())
-	}
-	r := NewMetricsReporter(true, 8080)
-
-	incrementBy := randCounterInc(t, r.IncrementTotalRequests)
-	if testutil.ToFloat64(collector) != float64(incrementBy) {
-		t.Fatalf("unexpected counter value for %s", collector.Desc().String())
-	}
-}
-
 func TestIncrementCacheHits(t *testing.T) {
 	collector := cacheHits
 	if testutil.ToFloat64(collector) != 0 {

--- a/pkg/threescale/threescale.go
+++ b/pkg/threescale/threescale.go
@@ -62,8 +62,6 @@ var _ authorization.HandleAuthorizationServiceServer = &Threescale{}
 func (s *Threescale) HandleAuthorization(ctx context.Context, r *authorization.HandleAuthorizationRequest) (*v1beta1.CheckResult, error) {
 	var result v1beta1.CheckResult
 
-	go s.conf.metricsReporter.IncrementTotalRequests()
-
 	log.Debugf("Got instance %+v", r.Instance)
 
 	if r.AdapterConfig == nil {


### PR DESCRIPTION
This code is not required since this information can be obtained from Prometheus by default.
Mixer will report all requests to all handlers and we can filter by adapter name.
Offloading the work from the adapter since it duplicates existing functionality.

To retrieve this metric query with `handle_authorization_requests{kubernetes_name="threescale-istio-adapter"}`