### PR TITLE
Makefile: Fixes integration test coverage reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ unit: ## Run unit tests
 	go test ./... -covermode=count -test.coverprofile="$(PROJECT_PATH)/_output/unit.cov"
 
 integration: ## Run integration tests
-	go test ./... -covermode=count -tags integration -test.coverprofile="$(PROJECT_PATH)/_output/integration.cov"
+	go test -covermode=count -tags integration -test.coverprofile="$(PROJECT_PATH)/_output/integration.cov" -run=TestAuthorizationCheck ./...
 
 test: unit integration ## Runs all tests
 


### PR DESCRIPTION
When passing build tags to the go test tool, it was believed that only tests with those tags would run.
However including build tags executes all tests and not just that of the passed tag.

This changes isolates the integration test and generates coverage for that only, restoring accuracy
of the coverage we gain by using the integration test framework.