### PR TITLE
dep: Update to latest version of 3scale backend client library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,15 +10,14 @@
   version = "v0.33.0"
 
 [[projects]]
-  digest = "1:e7d94a12452c0227d07d557b44b01d57a08772d12a603391cbacdd9ee792cd84"
+  digest = "1:e973a630b7d0ab7466215fcae007779c1760ae4af7fc4dba011ad9fc101a8f98"
   name = "github.com/3scale/3scale-go-client"
   packages = [
     "client",
     "fake",
   ]
   pruneopts = "NUT"
-  revision = "278f01eb0eab1d32267e38e7d59a5e7f2a1c2367"
-  version = "v0.0.1"
+  revision = "e366adc214e96578b5e53fd5b0250c5cfaec414c"
 
 [[projects]]
   digest = "1:91981d63946f5d802a03ab508e7d5a701f6c3f85100949719a467dd81033a9eb"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,7 +18,7 @@
 
 [[constraint]]
   name = "github.com/3scale/3scale-go-client"
-  version = "v0.0.1"
+  revision = "e366adc214e96578b5e53fd5b0250c5cfaec414c"
 
 [[constraint]]
   name = "github.com/3scale/3scale-porta-go-client"

--- a/pkg/threescale/threescale.go
+++ b/pkg/threescale/threescale.go
@@ -182,7 +182,7 @@ func (s *Threescale) doAuthRep(request authRepRequest, callback authRepFn, backe
 	)
 
 	start = time.Now()
-	resp, apiErr := callback(request.auth, request.authKey, request.svcID, request.params)
+	resp, apiErr := callback(request.auth, request.authKey, request.svcID, request.params, nil)
 	elapsed = time.Since(start)
 
 	go s.reportMetrics(request.svcID, prometheus.NewLatencyReport(endpoint, elapsed, backendEndpoint, target),

--- a/pkg/threescale/types.go
+++ b/pkg/threescale/types.go
@@ -34,7 +34,7 @@ type AdapterConfig struct {
 // reportMetrics - function that defines requirements for reporting metrics around interactions between 3scale and the adapter
 type reportMetrics func(serviceID string, l prometheus.LatencyReport, s prometheus.StatusReport)
 
-type authRepFn func(auth client.TokenAuth, key string, svcID string, params client.AuthRepParams) (client.ApiResponse, error)
+type authRepFn func(auth client.TokenAuth, key string, svcID string, params client.AuthRepParams, ext map[string]string) (client.ApiResponse, error)
 
 type authRepRequest struct {
 	svcID   string


### PR DESCRIPTION
This change fixes #81, as well as incoporating a client with support for additional
features such as rate limit and hierarchy extentions.