### PR TITLE
manifest_generator: fix rule reference to instance

### DIFF
--- a/pkg/templating/manifest_generator.go
+++ b/pkg/templating/manifest_generator.go
@@ -195,7 +195,7 @@ spec:
   actions:
   - handler: threescale-{{.GetUID}}.handler.istio-system
     instances:
-    - threescale-authorization-{{.GetUID}}`)
+    - threescale-authorization-{{.GetUID}}.instance.istio-system`)
 	if err != nil {
 		return err
 	}

--- a/pkg/templating/manifest_generator_test.go
+++ b/pkg/templating/manifest_generator_test.go
@@ -339,7 +339,7 @@ spec:
   actions:
   - handler: threescale-%s.handler.istio-system
     instances:
-    - threescale-authorization-%s`, testUid, host, testUid, testUid, testUid, testUid)
+    - threescale-authorization-%s.instance.istio-system`, testUid, host, testUid, testUid, testUid, testUid)
 
 	b := newTestBuffer(t)
 	err := defaultTestFixture.OutputRule(b)

--- a/testdata/threescale-adapter-config.yaml
+++ b/testdata/threescale-adapter-config.yaml
@@ -51,5 +51,5 @@ spec:
   actions:
   - handler: threescale-123456.handler.istio-system
     instances:
-    - threescale-authorization-123456
+    - threescale-authorization-123456.instance.istio-system
 ---


### PR DESCRIPTION
This suffix is required so that the mixer can find the right instance when applying the rule template.