### PR TITLE
istio/threescale-adapter-config.yml: fix instance reference in rule template

### DIFF
--- a/istio/threescale-adapter-config.yaml
+++ b/istio/threescale-adapter-config.yaml
@@ -44,5 +44,5 @@ spec:
   actions:
     - handler: threescale.handler.istio-system
       instances:
-        - threescale-authorization
+        - threescale-authorization.instance.istio-system
 ---


### PR DESCRIPTION
This was forgotten from PR #84 and should have been part of it.