### PR TITLE
OIDC integration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -278,14 +278,17 @@
   version = "v1.1.5"
 
 [[projects]]
-  branch = "master"
-  digest = "1:5d05f81d2061cd92e62a23d92c01060e9162bbc74962f876241bd4b3238bc6f3"
+  digest = "1:932f61879fdf354278ea76cd0bcca3776bff3a275867b2f967ddc59a6b17613e"
   name = "github.com/lestrrat-go/jwx"
   packages = [
     "internal/base64",
     "internal/option",
     "jwa",
     "jwk",
+    "jws",
+    "jws/sign",
+    "jws/verify",
+    "jwt",
   ]
   pruneopts = "NUT"
   revision = "e346d0eba260079c4fb03c5ccd0e62d92347ee03"
@@ -1134,7 +1137,9 @@
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/proto",
     "github.com/gogo/protobuf/types",
+    "github.com/lestrrat-go/jwx/jwa",
     "github.com/lestrrat-go/jwx/jwk",
+    "github.com/lestrrat-go/jwx/jwt",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/client_golang/prometheus/testutil",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -39,6 +39,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:c91a5363a19174cb0181832821a7bb9da0aeefb5e2180724614b1005c2269712"
+  name = "github.com/coreos/go-oidc"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "1180514eaf4d9f38d0d19eef639a1d695e066e72"
+  version = "v2.0.0"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -270,6 +278,27 @@
   version = "v1.1.5"
 
 [[projects]]
+  branch = "master"
+  digest = "1:5d05f81d2061cd92e62a23d92c01060e9162bbc74962f876241bd4b3238bc6f3"
+  name = "github.com/lestrrat-go/jwx"
+  packages = [
+    "internal/base64",
+    "internal/option",
+    "jwa",
+    "jwk",
+  ]
+  pruneopts = "NUT"
+  revision = "e346d0eba260079c4fb03c5ccd0e62d92347ee03"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b9c8c629d0a86a2a1e59620e4e85d1e1f6e5ffe1deb3b140c7bafcfea3b62ce5"
+  name = "github.com/lestrrat-go/pdebug"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "39f9a71bcabe9432cbdfe4d3d33f41988acd2ce6"
+
+[[projects]]
   digest = "1:0dbba7d4d4f3eeb01acd81af338ff4a3c4b0bb814d87368ea536e616f383240d"
   name = "github.com/lyft/protoc-gen-validate"
   packages = ["validate"]
@@ -376,6 +405,17 @@
   pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e91bc1b1cfb1a99107ad015ff3803071d13dc12924ed1fdf9c9d54346bcbbf6e"
+  name = "github.com/pquerna/cachecontrol"
+  packages = [
+    ".",
+    "cacheobject",
+  ]
+  pruneopts = "NUT"
+  revision = "1555304b9b35fdd2b425bccf1a5613677705e7d0"
 
 [[projects]]
   digest = "1:272ae9aa79d45a54ab842aa8d234d235e9bcb5a6d4acdd3a97d2436842e21049"
@@ -581,9 +621,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
+  digest = "1:8e241498e35f550e5192ee6b1f6ff2c0a7ffe81feff9541d297facffe1383979"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "pbkdf2",
+    "ssh/terminal",
+  ]
   pruneopts = "NUT"
   revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
 
@@ -731,6 +776,18 @@
   pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
+
+[[projects]]
+  digest = "1:b36ebe2478bf5da49c27d8c49d75d1d5cc7fdbd6be1ab464916f9c3a3e3228a4"
+  name = "gopkg.in/square/go-jose.v2"
+  packages = [
+    ".",
+    "cipher",
+    "json",
+  ]
+  pruneopts = "NUT"
+  revision = "628223f44a71f715d2881ea69afc795a1e9c01be"
+  version = "v2.3.0"
 
 [[projects]]
   digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
@@ -1071,11 +1128,13 @@
     "github.com/3scale/3scale-go-client/fake",
     "github.com/3scale/3scale-porta-go-client/client",
     "github.com/3scale/3scale-porta-go-client/fake",
+    "github.com/coreos/go-oidc",
     "github.com/ghodss/yaml",
     "github.com/gogo/googleapis/google/rpc",
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/proto",
     "github.com/gogo/protobuf/types",
+    "github.com/lestrrat-go/jwx/jwk",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/client_golang/prometheus/testutil",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,6 +36,10 @@
   name = "github.com/coreos/go-oidc"
   version = "v2.0.0"
 
+[[constraint]]
+  name = "github.com/lestrrat-go/jwx"
+  revision = "e346d0eba260079c4fb03c5ccd0e62d92347ee03"
+
 [prune]
   unused-packages = true
   go-tests = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,6 +32,10 @@
   name = "github.com/ghodss/yaml"
   version = "1.0.0"
 
+[[constraint]]
+  name = "github.com/coreos/go-oidc"
+  version = "v2.0.0"
+
 [prune]
   unused-packages = true
   go-tests = true

--- a/istio/threescale-adapter-config.yaml
+++ b/istio/threescale-adapter-config.yaml
@@ -28,6 +28,7 @@ spec:
       properties:
         app_id: request.query_params["app_id"] | request.headers["x-app-id"] | ""
         app_key: request.query_params["app_key"] | request.headers["x-app-key"] | ""
+        id_token: request.headers["authorisation"] | ""
     action:
       path: request.url_path
       method: request.method | "get"

--- a/pkg/threescale/oidc_handler.go
+++ b/pkg/threescale/oidc_handler.go
@@ -1,0 +1,71 @@
+package threescale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/coreos/go-oidc"
+)
+
+// OIDCHandler manages threescale services integrated with Istio using the OpenID connect authentication option.
+// For backwards compatibility the code here will need to match the behaviour of APIcast.
+// There are some interesting discussions around this so we need to keep in sync with changes.
+// See https://github.com/3scale/APIcast/issues/988 for some discussion related to this.
+// APIcast currently only supports RSA* family of signing
+type OIDCHandler struct {
+	context context.Context
+}
+
+// clientCredentials are user:password which can be stripped from a provided url if exist
+type clientCredentials struct {
+	clientId     string
+	clientSecret string
+}
+
+// Constructor for OIDCHandler
+// Accepts a client and if non provided will default to the http.DefaultClient
+func NewOIDCHandler(client *http.Client) *OIDCHandler {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	cc := oidc.ClientContext(context.TODO(), client)
+
+	return &OIDCHandler{
+		context: cc,
+	}
+}
+
+/*
+CreateProvider accepts an issuer URL as a string and strips will strip basic auth credentials from it if set.
+Uses OIDC discovery protocol to generate a OIDC provider, giving us access to the underlying JWK - See https://tools.ietf.org/html/rfc7517
+The function used here "NewProvider" calls "NewRemoteKeySet" internally which caches based on cache-control headers
+TODO - We might want to look at extending the TTL of these keys internally going forward
+*/
+func (o *OIDCHandler) CreateProvider(issuerUrl string) (*oidc.Provider, error) {
+	u, err := url.ParseRequestURI(issuerUrl)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing provided url - %s", issuerUrl)
+	}
+
+	_, issuer := stripCredentials(u)
+	p, err := oidc.NewProvider(o.context, issuer)
+	if err != nil {
+		err = fmt.Errorf("error creating OIDC provider " + err.Error())
+	}
+	return p, err
+}
+
+// strips basic auth from provided url and returns the credentials and stripped url as string
+func stripCredentials(u *url.URL) (clientCredentials, string) {
+	var cc clientCredentials
+	if u.User.String() != "" {
+		cc.clientId = u.User.Username()
+		cc.clientSecret, _ = u.User.Password()
+		stripped := strings.Replace(u.String(), u.User.String()+"@", "", -1)
+		return cc, stripped
+	}
+	return cc, u.String()
+}

--- a/pkg/threescale/oidc_handler_test.go
+++ b/pkg/threescale/oidc_handler_test.go
@@ -1,0 +1,178 @@
+package threescale
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/jwk"
+)
+
+var globalPK *rsa.PrivateKey
+
+func init() {
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(fmt.Errorf("failed to generate private key: %s", err))
+	}
+	globalPK = pk
+}
+
+func TestOIDCHandler_CreateProvider(t *testing.T) {
+	const listener = "127.0.0.1:8090"
+	const issuer = "http://" + listener
+
+	ts := createTestServer(listener, t)
+	o := NewOIDCHandler(nil)
+
+	// create provider aainst the test server and expect it to work without error and provider not be nil
+	p, err := o.CreateProvider(issuer)
+	if err != nil || p == nil {
+		t.Errorf("unexpected error when creating provider - %v", err)
+	}
+	ts.Close()
+
+	//retry after closing the server
+	o = NewOIDCHandler(&http.Client{
+		Timeout: time.Millisecond,
+	})
+	p, err = o.CreateProvider(issuer)
+	if err == nil || p != nil {
+		t.Errorf("expected error when creating provider - %v", err)
+	}
+
+	//create with invalid url
+	_, err = o.CreateProvider("~invalid")
+	if err == nil {
+		t.Errorf("expected error when creating provide with invalid url - %v", err)
+	}
+
+}
+
+func getDiscoveryResponse(providerUrl string) []byte {
+	return []byte(fmt.Sprintf(`{  
+   "issuer":"%s",
+   "authorization_endpoint":"%s/auth/realms/3scale-keycloak/protocol/openid-connect/auth",
+   "token_endpoint":"%s/auth/realms/3scale-keycloak/protocol/openid-connect/token",
+   "userinfo_endpoint":"%s/auth/realms/3scale-keycloak/protocol/openid-connect/userinfo",
+   "jwks_uri":"%s/auth/realms/3scale-keycloak/protocol/openid-connect/certs",
+   "grant_types_supported":[  
+      "authorization_code",
+      "implicit",
+      "refresh_token",
+      "password",
+      "client_credentials"
+   ],
+   "response_types_supported":[  
+      "code",
+      "none",
+      "id_token",
+      "token",
+      "id_token token",
+      "code id_token",
+      "code token",
+      "code id_token token"
+   ],
+   "subject_types_supported":[  
+      "public",
+      "pairwise"
+   ],
+   "id_token_signing_alg_values_supported":[  
+      "ES384",
+      "RS384",
+      "HS256",
+      "HS512",
+      "ES256",
+      "RS256",
+      "HS384",
+      "ES512",
+      "RS512"
+   ],
+   "userinfo_signing_alg_values_supported":[  
+      "ES384",
+      "RS384",
+      "HS256",
+      "HS512",
+      "ES256",
+      "RS256",
+      "HS384",
+      "ES512",
+      "RS512",
+      "none"
+   ],
+   "request_object_signing_alg_values_supported":["none","RS256"],
+   "response_modes_supported":["query"],
+   "registration_endpoint":"http://keycloak-keycloak.34.242.107.254.nip.io/auth/realms/3scale-keycloak/clients-registrations/openid-connect",
+   "token_endpoint_auth_methods_supported":[  
+      "private_key_jwt",
+      "client_secret_basic",
+      "client_secret_post",
+      "client_secret_jwt"
+   ],
+   "token_endpoint_auth_signing_alg_values_supported":["RS256","HS256"],
+   "claims_supported":[  
+      "sub",
+      "iss",
+      "name"
+   ],
+   "claim_types_supported":["normal"],
+   "claims_parameter_supported":false,
+   "scopes_supported":["openid"],
+   "request_parameter_supported":true,
+   "request_uri_parameter_supported":true,
+   "code_challenge_methods_supported":["plain","S256"]
+}`, providerUrl, providerUrl, providerUrl, providerUrl, providerUrl))
+}
+
+func buildJwk(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := jwk.New(&globalPK.PublicKey)
+	if err != nil {
+		t.Fatalf("failed to create JWK: %s", err)
+	}
+
+	key.Set(jwk.KeyUsageKey, "enc")
+	key.Set(jwk.KeyIDKey, "enc1")
+
+	b, err := json.MarshalIndent(key, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to generate JSON: %s", err)
+	}
+
+	str := fmt.Sprintf(`{"keys":[%s]}`, string(b))
+	b = []byte(str)
+
+	return b
+}
+
+// creates and starts a test server which listens on provided ip:port
+// this acts as a fake OIDC provider. This starts the server and the caller is responsible for closing
+// the connection when done.
+func createTestServer(listenOn string, t *testing.T) *httptest.Server {
+	t.Helper()
+	issuer := fmt.Sprintf("http://%s", listenOn)
+	l, err := net.Listen("tcp", listenOn)
+	if err != nil {
+		t.Fatalf("error listening on port for test data")
+	}
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if strings.Contains(r.URL.Path, "auth/realms/3scale-keycloak/protocol/openid-connect/certs") {
+			w.Write(buildJwk(t))
+		} else {
+			w.Write(getDiscoveryResponse(issuer))
+		}
+	}))
+	ts.Listener = l
+	ts.Start()
+	return ts
+}

--- a/testdata/threescale-adapter-config.yaml
+++ b/testdata/threescale-adapter-config.yaml
@@ -33,6 +33,7 @@ spec:
       properties:
         app_id: request.query_params["app_id"] | request.headers["app-id"] | ""
         app_key: request.query_params["app_key"] | request.headers["app-key"] | ""
+        id_token: request.headers["authorisation"] | ""
     action:
       path: request.url_path
       method: request.method | "get"


### PR DESCRIPTION
This PR adds a starting point for discussion around OIDC integration. I have integrated 3scale with Keycloak and tested this E2E.

- [x] Describe what's going on here 
- [x] Discuss alternative flow
- [ ] Fix unit tests post discussion for other packages
- [ ] Add integration test when we have decided how we want to do this for sure


### What does this change do?

Currently, this code behaves much the same way as APIcast currently does in 3scale OIDC authentication pattern flow and is intended to provide the same functionality as of now. The flow is described below:

1. The request hits the adapter via the ingress gateway --> mixer as before
1. The adapter reads the proxy configuration from 3scale for the incoming request via service id
1. Adapter determines if the OIDC integration has been enabled for this service on 3scale
1. If OIDC is configured, the adapter expects the JWT to be present in the header (this is reachable via attribute and must be set in the config) `id_token: request.headers["authorisation"] | ""`
1. At this point, fail as unauthorised if no token present
1. Assuming token is present adapter uses the issuer url in system config to create a provider which uses OIDC discovery protocol to fetch and maintain a key set (public keys of provider) (currently only supporting RSA* family as per APIcast)
1. The raw JWT is verified at this point against the providers keys, returning authn failed if unsuccessful
1. If validated, the adapter will parse the JWT claims for a value matching a provided label( currently only supporting `azp`  for Keycloak but we should be able to configure this either via system config or as  header/param to adapter)
1. The value of the provided label on the claims is used as an `app_id` in AuthRep request to 3scale backend and the result returned (accept/deny)

#### Limitations
1. As this is just an initial attempt, each request creates a new provider. This should be cached going forward. A providers key set is cached based on cache-control headers by the underlying library used
