### PR TITLE
cli/main: autoenable fixup mode when no uid present

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -1,7 +1,7 @@
 ## CustomResource Generator
 
 This program produces sample CustomResource definitions for [handler](https://istio.io/docs/concepts/policies-and-telemetry/#handlers),
- [instance](https://istio.io/docs/concepts/policies-and-telemetry/#instances) 
+ [instance](https://istio.io/docs/concepts/policies-and-telemetry/#instances)
  and [rule](https://istio.io/docs/concepts/policies-and-telemetry/#rules) CustomResources.
 
 The manifests produced are tested against the integration test suite in the gRPC adapter code and support multiple services,
@@ -17,8 +17,23 @@ The program accepts a number of flags which are documented in the table below:
 |    `-t`, `--token`   |  3scale access token                                                    |   Yes   |         |
 |    `-u`, `--url`     |  3scale Admin Portal URL                                                |   Yes   |         |
 |    `-s`, `--service` |  3scale API/Service ID                                                  |   Yes   |         |
-|    `--uid`           |  Unique UID for resource names. Derived from URL and service  if unset  |   No    |         |
-|    `--fixup`         |  Try to automatically fix validation errors                             |   No    | False   |
+|    `--uid`           |  Unique UID for resource names. Derived from URL and service if unset   |   No    |         |
+|    `--fixup`         |  Try to automatically fix validation errors. Autoenabled if --uid unset |   No    | False   |
 |    `--auth`          |  3scale authentication pattern to specify (1=Api Key, 2=App Id/App Key) |   No    | Hybrid  |
 |    `-o`, `--output`  |  File to save produced manifests to                                     |   No    | STDOUT  |
-|    `-v`              |  Outputs the CLI version                                                |   No    |         |
+|    `-v`              |  Outputs the CLI version (and exits right away)                         |   No    |         |
+
+### Example
+
+This example will generate the templates just from the URL, service and personal
+token:
+> 3scale-gen-config --url="https://myorg-admin.3scale.net:443" --service="123456789" --token="[redacted]"
+
+This example will generate the templates just like above but with a specific
+unique ID, which otherwise would have been derived from the URL:
+> 3scale-gen-config --url="https://myorg-admin.3scale.net" --uid="my-unique-id" --service="123456789" --token="[redacted]"
+
+The previous example might have failed to pass validation if the given unique ID
+did contain some special characters, so you might want to use the fixup mode to
+have the tool autocorrect those:
+> 3scale-gen-config --url="https://myorg-admin.3scale.net" --uid="my-unique-id" --fixup --service="123456789" --token="[redacted]"

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -61,7 +61,7 @@ func init() {
 		if version == "" {
 			version = "undefined"
 		}
-		log.Printf("3scale-config-gen version is %s", version)
+		fmt.Printf("3scale-config-gen version %s\n", version)
 		os.Exit(0)
 	}
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -169,10 +169,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	// ensure we either have a UID or we request the URL derivation to be fixed up
+	if uid == "" {
+		if !fixup {
+			log.Println("info: UID derivation from URL requires fixup mode, enabling.")
+		}
+		fixup = true
+	}
+
 	errs = execute()
 	if errs != nil {
 		for _, i := range errs {
 			fmt.Println(i.Error())
+		}
+		if !fixup {
+			log.Println("info: you might want to try --fixup to autocorrect the above errors.")
 		}
 		os.Exit(1)
 	}


### PR DESCRIPTION
While at it, add some examples in the tool's README, and we'll also suggest using `--fixup` if errors are present and the flag was not being used.

Fixes #90