### PR TITLE
Dockerfile: use Red Hat's RHEL 8 Universal Base Image (UBI) as container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,43 @@
-FROM golang:1.10 AS build
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS build
 
-ARG VERSION="undefined"
-ENV WORKDIR=/go/src/github.com/3scale/3scale-istio-adapter
+ENV GOPATH=/go
 
-ADD . ${WORKDIR}
-WORKDIR ${WORKDIR}
+RUN microdnf update --nodocs -y \
+ && microdnf install --nodocs -y findutils git go-toolset make perl-Digest-SHA \
+ && microdnf clean all -y \
+ && rm -rf /var/cache/yum
 
-RUN go get -u github.com/golang/dep/cmd/dep && \
-    make build-adapter VERSION=${VERSION} && \
-    make build-cli VERSION=${VERSION}
+ARG DEP_VERSION=v0.5.3
 
-FROM centos
+RUN mkdir -p "${GOPATH}/src/github.com/golang" \
+ && cd "${GOPATH}/src/github.com/golang" \
+ && git clone --depth 1 --recurse-submodules --shallow-submodules \
+      --branch "${DEP_VERSION}" https://github.com/golang/dep.git dep \
+ && cd dep \
+ && mkdir -p "${GOPATH}/bin" \
+ && make install
+
+ARG BUILDDIR="${GOPATH}/src/github.com/3scale/3scale-istio-adapter"
+WORKDIR "${BUILDDIR}"
+
+ARG VERSION=
+
+ADD . "${BUILDDIR}"
+RUN PATH="${PATH}:${GOPATH//://bin:}/bin" \
+ && if test "x${VERSION}" = "x"; then \
+      VERSION="$(git describe --dirty --tags || true)" ; \
+    fi \
+ && make VERSION="${VERSION:? *** No VERSION could be derived, please specify it}" \
+      build-adapter build-cli
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /app
-COPY --from=build /go/src/github.com/3scale/3scale-istio-adapter/_output/3scale-istio-adapter /app/
-COPY --from=build /go/src/github.com/3scale/3scale-istio-adapter/_output/3scale-config-gen /app/
+COPY --from=build "${BUILDDIR}/_output/3scale-istio-adapter" /app/
+COPY --from=build "${BUILDDIR}/_output/3scale-config-gen" /app/
 ENV THREESCALE_LISTEN_ADDR 3333
 EXPOSE 3333
 EXPOSE 8080
-ENTRYPOINT ./3scale-istio-adapter
+
+CMD ./3scale-istio-adapter
 


### PR DESCRIPTION
This new Dockerfile is based on RHEL 8's UBI minimal image for runtime, and uses the RHEL 8's UBI image for building, using golang 1.11.

The VERSION argument is now automatically derived at build time unless explicitly specified.