### PR TITLE
Dockerfile: Duplicate args across build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS build
 
 ENV GOPATH=/go
+ARG BUILDDIR="/go/src/github.com/3scale/3scale-istio-adapter"
 
 RUN microdnf update --nodocs -y \
  && microdnf install --nodocs -y findutils git go-toolset make perl-Digest-SHA \
@@ -17,7 +18,6 @@ RUN mkdir -p "${GOPATH}/src/github.com/golang" \
  && mkdir -p "${GOPATH}/bin" \
  && make install
 
-ARG BUILDDIR="${GOPATH}/src/github.com/3scale/3scale-istio-adapter"
 WORKDIR "${BUILDDIR}"
 
 ARG VERSION=
@@ -31,6 +31,8 @@ RUN PATH="${PATH}:${GOPATH//://bin:}/bin" \
       build-adapter build-cli
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+ARG BUILDDIR="/go/src/github.com/3scale/3scale-istio-adapter"
 
 WORKDIR /app
 COPY --from=build "${BUILDDIR}/_output/3scale-istio-adapter" /app/


### PR DESCRIPTION
Docker multi-stage builds, by design do not allow sharing of ARG and ENV
instructions outside the scopes they are defined in.
The previous changes worked as they were tested against podman, however they failed on quay.io

Ideally, we will declare required ARG and ENV, at "global scope" allowing them to be shared and keep the file DRY, however, because of an issue with this previous format on quay.io, where the Dockerfile was parsed by quay as invalid due to not starting with the FROM instruction, this change repeats
required ARGS and ENV across build stages bringing them into scope in each case.