### PR TITLE
Support gRPC load balancing between mixer and the adapter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1125,6 +1125,7 @@
     "github.com/prometheus/client_golang/prometheus/testutil",
     "github.com/spf13/viper",
     "google.golang.org/grpc",
+    "google.golang.org/grpc/keepalive",
     "istio.io/api/mixer/adapter/model/v1beta1",
     "istio.io/api/policy/v1beta1",
     "istio.io/istio/mixer/pkg/adapter/test",
@@ -1141,10 +1142,11 @@
     "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
+    "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/rest/fake",
+    "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/clientcmd",
-    "k8s.io/client-go/util/homedir",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/server/README.md
+++ b/cmd/server/README.md
@@ -12,6 +12,7 @@ configuring the following environment variables:
 | THREESCALE_LISTEN_ADDR           | Sets the listen address for the gRPC server                                                        | 0       |
 | THREESCALE_LOG_LEVEL             | Sets the minimum log output level. Accepted values are one of `debug`,`info`,`warn`,`error`,`none` | info    |
 | THREESCALE_LOG_JSON              | Controls whether the log is formatted as JSON                                                      | true    |
+| THREESCALE_LOG_GRPC              | Controls whether the log includes gRPC info                                                           | false   |
 | THREESCALE_REPORT_METRICS        | Controls whether 3scale system and backend metrics are collected and reported to Prometheus        | true    |
 | THREESCALE_METRICS_PORT          | Sets the port which 3scale `/metrics` endpoint can be scrapped from                                | 8080    |
 | THREESCALE_CACHE_TTL_SECONDS     | Time period, in seconds, to wait before purging expired items from the cache                       | 300     |
@@ -20,6 +21,7 @@ configuring the following environment variables:
 | THREESCALE_CACHE_REFRESH_RETRIES | Sets the number of times unreachable hosts will be retried during a cache update loop              | 1       |
 | THREESCALE_ALLOW_INSECURE_CONN   | Allow to skip certificate verification when calling 3scale API's. Enabling is not recommended      | false   |
 | THREESCALE_CLIENT_TIMEOUT_SECONDS| Sets the number of seconds to wait before terminating requests to 3scale System and Backend        | 10      |
+| THREESCALE_GRPC_CONN_MAX_SECONDS | Sets the maximum amount of seconds (+/-10% jitter) a connection may exist before it will be closed | 1       |
 
 #### Caching behaviour
 By default, responses from 3scale System API's will be cached. Entries will be purged from the cache when they

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -38,6 +38,8 @@ func init() {
 	viper.BindEnv("client_timeout_seconds")
 	viper.BindEnv("allow_insecure_conn")
 
+	viper.BindEnv("grpc_conn_max_seconds")
+
 	options := istiolog.DefaultOptions()
 
 	if viper.IsSet("log_level") {
@@ -154,7 +156,12 @@ func main() {
 
 	proxyCache := cacheConfigBuilder()
 
-	adapterConfig := threescale.NewAdapterConfig(proxyCache, parseMetricsConfig())
+	grpcKeepAliveFor := time.Minute
+	if viper.IsSet("grpc_conn_max_seconds") {
+		grpcKeepAliveFor = time.Second * time.Duration(viper.GetInt("grpc_conn_max_seconds"))
+	}
+	adapterConfig := threescale.NewAdapterConfig(proxyCache, parseMetricsConfig(), grpcKeepAliveFor)
+
 	s, err := threescale.NewThreescale(addr, parseClientConfig(), adapterConfig)
 
 	if err != nil {

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -17,3 +17,4 @@ spec:
       name: prometheus
   selector:
     app: 3scale-istio-adapter
+  clusterIP: None

--- a/pkg/kubernetes/threescale.go
+++ b/pkg/kubernetes/threescale.go
@@ -55,7 +55,7 @@ func NewThreescaleHandlerSpec(accessToken, systemURL, svcID string) (*HandlerSpe
 			AccessToken: accessToken,
 		},
 		Connection: v1beta1.Connection{
-			Address: fmt.Sprintf("%s:%d", defaultThreescaleAdapterListenAddress, defaultThreescaleAdapterListenPort),
+			Address: fmt.Sprintf("dns:///%s:%d", defaultThreescaleAdapterListenAddress, defaultThreescaleAdapterListenPort),
 		},
 	}, nil
 }

--- a/pkg/kubernetes/threescale_test.go
+++ b/pkg/kubernetes/threescale_test.go
@@ -55,7 +55,7 @@ func TestNewThreescaleHandlerSpec(t *testing.T) {
 					AccessToken: "12345",
 				},
 				Connection: v1beta1.Connection{
-					Address: defaultThreescaleAdapterListenAddress + ":" + strconv.Itoa(defaultThreescaleAdapterListenPort),
+					Address: "dns:///" + defaultThreescaleAdapterListenAddress + ":" + strconv.Itoa(defaultThreescaleAdapterListenPort),
 				},
 			},
 		},
@@ -73,7 +73,7 @@ func TestNewThreescaleHandlerSpec(t *testing.T) {
 					AccessToken: "12345",
 				},
 				Connection: v1beta1.Connection{
-					Address: defaultThreescaleAdapterListenAddress + ":" + strconv.Itoa(defaultThreescaleAdapterListenPort),
+					Address: "dns:///" + defaultThreescaleAdapterListenAddress + ":" + strconv.Itoa(defaultThreescaleAdapterListenPort),
 				},
 			},
 		},

--- a/pkg/threescale/threescale.go
+++ b/pkg/threescale/threescale.go
@@ -370,16 +370,16 @@ func NewThreescale(addr string, client *http.Client, conf *AdapterConfig) (Serve
 	log.Infof("Threescale Istio Adapter is listening on \"%v\"\n", s.Addr())
 
 	s.server = grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{
-		MaxConnectionAge: 1 * time.Minute,
+		MaxConnectionAge: conf.keepAliveMaxAge,
 	}))
 	authorization.RegisterHandleAuthorizationServiceServer(s.server, s)
 	return s, nil
 }
 
 // NewAdapterConfig - Creates configuration for Threescale adapter
-func NewAdapterConfig(cache *ProxyConfigCache, metrics *prometheus.Reporter) *AdapterConfig {
+func NewAdapterConfig(cache *ProxyConfigCache, metrics *prometheus.Reporter, grpcKeepalive time.Duration) *AdapterConfig {
 	if cache != nil {
 		cache.metricsReporter = metrics
 	}
-	return &AdapterConfig{cache, metrics}
+	return &AdapterConfig{cache, metrics, grpcKeepalive}
 }

--- a/pkg/threescale/threescale.go
+++ b/pkg/threescale/threescale.go
@@ -24,6 +24,7 @@ import (
 	sysC "github.com/3scale/3scale-porta-go-client/client"
 	"github.com/gogo/googleapis/google/rpc"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"istio.io/api/mixer/adapter/model/v1beta1"
 	"istio.io/istio/mixer/pkg/status"
 	"istio.io/istio/mixer/template/authorization"
@@ -368,7 +369,9 @@ func NewThreescale(addr string, client *http.Client, conf *AdapterConfig) (Serve
 
 	log.Infof("Threescale Istio Adapter is listening on \"%v\"\n", s.Addr())
 
-	s.server = grpc.NewServer()
+	s.server = grpc.NewServer(grpc.KeepaliveParams(keepalive.ServerParameters{
+		MaxConnectionAge: 1 * time.Minute,
+	}))
 	authorization.RegisterHandleAuthorizationServiceServer(s.server, s)
 	return s, nil
 }

--- a/pkg/threescale/threescale_test.go
+++ b/pkg/threescale/threescale_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gogo/googleapis/google/rpc"
 
@@ -227,7 +228,7 @@ func TestHandleAuthorization(t *testing.T) {
 
 func Test_NewThreescale(t *testing.T) {
 	addr := "0"
-	threescaleConf := NewAdapterConfig(nil, nil)
+	threescaleConf := NewAdapterConfig(nil, nil, time.Minute)
 	s, err := NewThreescale(addr, http.DefaultClient, threescaleConf)
 	if err != nil {
 		t.Errorf("Error running threescale server %#v", err)

--- a/pkg/threescale/types.go
+++ b/pkg/threescale/types.go
@@ -3,6 +3,7 @@ package threescale
 import (
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/3scale/3scale-go-client/client"
 
@@ -29,6 +30,7 @@ type Threescale struct {
 type AdapterConfig struct {
 	systemCache     *ProxyConfigCache
 	metricsReporter *prometheus.Reporter
+	keepAliveMaxAge time.Duration
 }
 
 // reportMetrics - function that defines requirements for reporting metrics around interactions between 3scale and the adapter


### PR DESCRIPTION
This change makes the service "Headless" returning a set of A records for the backing pods. 
Adding a max connection age to the gRPC server forces mixer to reconnect at intervals and pick up additional pods.

~~This change depends on https://github.com/istio/istio/pull/14607 to work effectively but remains compatible so is safe to merge.~~