### PR TITLE
Local cluster setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 
 _output/
 
+*kubeconfig.yaml
+
 # OS generated files #
 ######################
 .DS_Store

--- a/istio/samples/httpbin/httpbin-gateway.yaml
+++ b/istio/samples/httpbin/httpbin-gateway.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: httpbin-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: httpbin
+spec:
+  hosts:
+    - "*"
+  gateways:
+    - httpbin-gateway
+  http:
+    - match:
+        - uri:
+            prefix: "/httpbin"
+      rewrite:
+        uri: "/"
+      route:
+        - destination:
+            host: httpbin
+            port:
+              number: 8000

--- a/istio/samples/httpbin/httpbin.yaml
+++ b/istio/samples/httpbin/httpbin.yaml
@@ -1,0 +1,49 @@
+# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# httpbin service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 80
+  selector:
+    app: httpbin
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      containers:
+        - image: docker.io/kennethreitz/httpbin
+          imagePullPolicy: IfNotPresent
+          name: httpbin
+          ports:
+            - containerPort: 80

--- a/scripts/istio-utils.sh
+++ b/scripts/istio-utils.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# A set of utility functions for working with Istio
+# Calls to kubectl expects KUBECONFIG environment variable to be set correctly.
+
+
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+root_dir=$(dirname "${script_dir}")
+output_dir="${root_dir}"/_output
+sample_dir="${root_dir}"/istio/samples
+
+
+# get_istio_version attempts to parse the istio version from Gopkg.toml if not set.
+# If parsing fails, default to setting to the latest version.
+function get_istio_version() {
+    if [[ "x${ISTIO_VERSION}" = "x" ]] ; then
+        # not using regex here because of some compatibility issues across different OS
+        ISTIO_VERSION=$(grep -A 1 "istio.io/istio" ${root_dir}/Gopkg.toml | grep "version" | cut -d'"' -f 2 | tr -d "=<>~^")
+    fi
+
+    if [[ "x${ISTIO_VERSION}" = "x" ]] ; then
+      echo "Unable to parse Istio version from dependencies - attempting to use latest version"
+      ISTIO_VERSION=$(curl -L -s https://api.github.com/repos/istio/istio/releases/latest | \
+                      grep tag_name | sed "s/ *\"tag_name\": *\"\\(.*\\)\",*/\\1/")
+    fi
+
+    if [[ "x${ISTIO_VERSION}" = "x" ]] ; then
+      printf "Unable to get latest Istio version. Set ISTIO_VERSION env var and re-run. For example: export ISTIO_VERSION=1.1.11"
+      exit;
+    fi
+
+    printf ${ISTIO_VERSION}
+}
+
+
+# get_istio downloads specified Istio source
+function get_istio() {
+    version=$(get_istio_version)
+
+    OS="$(uname)"
+    if [[ "x${OS}" = "xDarwin" ]] ; then
+      OSEXT="osx"
+    else
+      OSEXT="linux"
+    fi
+
+    NAME="istio-${version}"
+    URL="https://github.com/istio/istio/releases/download/${version}/istio-${version}-${OSEXT}.tar.gz"
+    if ! [[ -d ${output_dir}/${NAME} ]]; then
+      printf "Downloading %s from %s ..." "$NAME" "$URL"
+      mkdir - p "${output_dir}" && cd "${output_dir}" && curl -L "$URL" | tar xz
+    fi
+}
+
+function build_istio_src_dir() {
+        istio_version=$(get_istio_version)
+        ISTIO_SRC=${output_dir}/istio-${istio_version}
+        printf ${ISTIO_SRC}
+}
+
+# install_istio relies on helm to install a default istio deployment
+# accepts path to istio source as arg - if not set attempts to build path from environment
+function install_istio() {
+    ISTIO_SRC=$1
+    if [[ -z "${ISTIO_SRC}" ]]
+    then
+        ISTIO_SRC=$(build_istio_src_dir)
+    fi
+
+    kubectl create ns istio-system || true
+    helm template ${ISTIO_SRC}/install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
+
+    # we need to wait for the custom resources installed by the previous command to be committed to the k8-api
+    crd_target_count=$(find ${ISTIO_SRC}/install/kubernetes/helm/istio-init/files -name "crd-[0-9]*" | xargs grep "kind: CustomResourceDefinition" | wc -l)
+
+    ready=false
+    for i in {1..12};do
+        crd_count=$(kubectl get crds -n istio-system | grep 'istio.io\|certmanager.k8s.io' | wc -l)
+        if [[ ${crd_count} -gt $(( ${crd_target_count} - 1 )) ]] ;then ready=true && break; fi
+        sleep 5
+    done;
+
+    if [[ ${ready} != "true" ]]; then echo "Required CRD missing" &&  exit 1; fi
+
+
+    # here we need to disable validation/injector functionality which use webhooks since k3s does not yet support that
+    # we are re-enabling policies since this is required for the 3scale adapter to work correctly
+    helm template ${ISTIO_SRC}/install/kubernetes/helm/istio --name istio --namespace istio-system \
+        --set global.configValidation=false --set sidecarInjectorWebhook.enabled=false \
+        --set global.disablePolicyChecks=false | kubectl apply -f -
+
+    kubectl rollout status deploy/istio-ingressgateway -n istio-system
+}
+
+
+function deploy_httpbin() {
+    kubectl create namespace httpbin || true
+
+    kubectl -n istio-system get configmap istio-sidecar-injector -o=jsonpath='{.data.config}' > ${output_dir}/inject-config.yaml
+    kubectl -n istio-system get configmap istio -o=jsonpath='{.data.mesh}' > ${output_dir}/mesh-config.yaml
+
+    TARGET_DIRECTORY=$(build_istio_src_dir)
+    ${TARGET_DIRECTORY}/bin/istioctl kube-inject \
+        --injectConfigFile ${output_dir}/inject-config.yaml \
+        --meshConfigFile ${output_dir}/mesh-config.yaml \
+        --filename ${sample_dir}/httpbin/httpbin.yaml \
+        --output ${output_dir}/injected.yaml
+
+    kubectl apply -f ${output_dir}/injected.yaml --namespace httpbin
+    kubectl apply -f ${sample_dir}/httpbin/httpbin-gateway.yaml --namespace httpbin
+    kubectl rollout status deploy/httpbin --namespace httpbin
+}

--- a/scripts/local-cluster/README.md
+++ b/scripts/local-cluster/README.md
@@ -1,0 +1,63 @@
+### K3s Cluster
+
+This directory contains scripts and manifests to deploy a local, lightweight cluster based on [k3s](https://github.com/rancher/k3s).
+
+#### Requirements
+
+1. Docker
+1. kubectl
+1. helm
+
+#### Running
+
+The `make` targets in the project root with the prefix `local.cluster.*` can be used to initiate various stages.
+
+Provided functionality includes:
+
+1. Bring up a local k3s cluster suitable for deploying Istio to - `make local.cluster.up`.
+1. Install Istio into the local cluster (expects cluster to be running) - `make local.install-istio`.
+1. Install 3scale-istio-adapter into local cluster (expects cluster to be running) - `make local.install-adapter`.
+1. Install [httpbin](https://httpbin.org) in local cluster (expects cluster to be running) - `make local.cluster.install-httpbin`.
+1. A wrapper target to carry out all of the above steps - `make local.cluster.install-environment`.
+1. A clean target, to delete the cluster and all associated applications - `make local.cluster.clean`.
+
+A specific version of Istio can be installed by specifying the `ISTIO_VERSION=x.y.z` variable when running `make.local.*`
+
+##### Working with the cluster
+
+To interact with the cluster you will need to set `kubectl` to use the generated (after cluster creation) `kubeconfig.yaml` located in `3scale-istio-adapter/scripts/local-cluster`.
+This can be used in two ways:
+
+ 1. export KUBECONFIG=`<some-path>/3scale-istio-adapter/scripts/local-cluster/kubeconfig.yaml` - This is then active for the entire session.
+ 1. Pass the --kubeconfig=`<some-path>/3scale-istio-adapter/scripts/local-cluster/kubeconfig.yaml` flag on each call to `kubectl`.
+
+
+#### Cluster Ingress
+
+Assuming the `local.cluster.environment` make target has been used to bring up the cluster, Istio will be used as the ingress gateway.
+For convenience, the ports have been mapped to the host, so services can be reached via `8080`, and `8443` on localhost.
+
+Test the clusters functionality by running the following:
+
+`curl "http://127.0.0.1:8080/httpbin/get" -H "accept: application/json"`
+
+
+#### Troubleshooting
+
+##### DNS
+
+So you are having DNS issues?
+
+If your Pods cannot resolve external hostnames, check the logs from the `coredns` Pod in `kube-system` namespace.
+It is likely you will see i/o timeouts for services running on port 53 pointing some DNS issue in your environment.
+
+The following command will patch the appropriate ConfigMap. Replace `8.8.8.8` with your own nameservers' ip address:
+
+```yaml
+kubectl get cm coredns -n kube-system -o yaml | sed -e 's/proxy . \/etc\/resolv.conf/proxy . 8.8.8.8/g' | kubectl apply -f -
+```
+
+Restart the Pod:
+```yaml
+kubectl delete po -n kube-system -l k8s-app=kube-dns
+```

--- a/scripts/local-cluster/docker-compose.yaml
+++ b/scripts/local-cluster/docker-compose.yaml
@@ -1,0 +1,34 @@
+## Based from the content at https://github.com/rancher/k3s/blob/master/docker-compose.yml
+
+version: '3'
+services:
+  server:
+    image: rancher/k3s:v0.6.1
+    command: server --disable-agent --no-deploy traefik
+    environment:
+      - K3S_CLUSTER_SECRET=secret
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    volumes:
+      - k3s-server:/var/lib/rancher/k3s
+      - .:/output
+    ports:
+      - 6443:6443
+
+  node:
+    image: rancher/k3s:v0.6.1
+    tmpfs:
+      - /run
+      - /var/run
+    privileged: true
+    depends_on:
+      - server
+    ports:
+      - 8080:80
+      - 8443:443
+    environment:
+      - K3S_URL=https://server:6443
+      - K3S_CLUSTER_SECRET=secret
+
+volumes:
+  k3s-server: {}


### PR DESCRIPTION
This provides a base for the e2e testing story. Allowing us to quickly bring up a local cluster with the adapter installed alongside specified version of upstream Istio.

It also includes functionality to install httpbin service used in our QE testing suite.