### PR TITLE
Refactor backend

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -160,7 +160,7 @@ func main() {
 	if viper.IsSet("grpc_conn_max_seconds") {
 		grpcKeepAliveFor = time.Second * time.Duration(viper.GetInt("grpc_conn_max_seconds"))
 	}
-	adapterConfig := threescale.NewAdapterConfig(proxyCache, parseMetricsConfig(), grpcKeepAliveFor)
+	adapterConfig := threescale.NewAdapterConfig(proxyCache, parseMetricsConfig(), nil, grpcKeepAliveFor)
 
 	s, err := threescale.NewThreescale(addr, parseClientConfig(), adapterConfig)
 

--- a/pkg/threescale/connectors/backend/backend.go
+++ b/pkg/threescale/connectors/backend/backend.go
@@ -1,0 +1,85 @@
+package backend
+
+import (
+	"time"
+
+	backend "github.com/3scale/3scale-go-client/client"
+	"github.com/3scale/3scale-istio-adapter/pkg/threescale/metrics"
+)
+
+// Wrapper for requirements for 3scale AuthRep API
+type AuthRepRequest struct {
+	//required
+	ServiceID string
+	//required
+	Request backend.Request
+	//optional
+	Params backend.AuthRepParams
+}
+
+// Backend for 3scale API management
+// Operations supported by this interface require a client as we need to be able to call against multiple remote backends
+type Backend interface {
+	AuthRep(req AuthRepRequest, c *backend.ThreeScaleClient) (Response, error)
+}
+
+// Response is the result from calling the remote 3scale API
+type Response struct {
+	Reason     string
+	StatusCode int
+	Success    bool
+}
+
+// DefaultBackend is a simple implementation which disregards any caching implementation and calls 3scale directly
+// Supports reporting metrics.
+type DefaultBackend struct {
+	ReportFn metrics.ReportMetricsFn
+}
+
+// metricsConfig wraps the labels required for reporting metrics allowing them to be set in functions as desired
+type metricsConfig struct {
+	Endpoint string
+	ReportFn metrics.ReportMetricsFn
+	Target   metrics.Target
+}
+
+// AuthRep provides a combination of authorizing a request and reporting metrics to 3scale
+func (db DefaultBackend) AuthRep(req AuthRepRequest, c *backend.ThreeScaleClient) (Response, error) {
+	mc := metricsConfig{
+		ReportFn: db.ReportFn,
+		Endpoint: "AuthRep",
+		Target:   "Backend",
+	}
+
+	resp, err := callRemote(req, nil, c, mc)
+	if err != nil {
+		return Response{}, err
+	}
+	return convertResponse(resp), nil
+}
+
+func callRemote(req AuthRepRequest, ext map[string]string, c *backend.ThreeScaleClient, mc metricsConfig) (backend.ApiResponse, error) {
+	var (
+		start   time.Time
+		elapsed time.Duration
+	)
+
+	start = time.Now()
+	resp, apiErr := c.AuthRep(req.Request, req.ServiceID, req.Params, ext)
+	elapsed = time.Since(start)
+
+	if mc.ReportFn != nil {
+		go mc.ReportFn(req.ServiceID, metrics.NewLatencyReport(mc.Endpoint, elapsed, c.GetPeer(), mc.Target),
+			metrics.NewStatusReport(mc.Endpoint, resp.StatusCode, c.GetPeer(), mc.Target))
+	}
+
+	return resp, apiErr
+}
+
+func convertResponse(original backend.ApiResponse) Response {
+	return Response{
+		Reason:     original.Reason,
+		StatusCode: original.StatusCode,
+		Success:    original.Success,
+	}
+}

--- a/pkg/threescale/connectors/backend/backend_test.go
+++ b/pkg/threescale/connectors/backend/backend_test.go
@@ -1,0 +1,111 @@
+package backend
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/3scale/3scale-go-client/client"
+	"github.com/3scale/3scale-go-client/fake"
+	"github.com/3scale/3scale-istio-adapter/pkg/threescale/metrics"
+)
+
+func TestDefaultBackend(t *testing.T) {
+	var reported = false
+	var wg = sync.WaitGroup{}
+	mockRequest := AuthRepRequest{
+		Request: client.Request{
+			Credentials: client.TokenAuth{
+				Type:  "provider_key",
+				Value: "any",
+			},
+		},
+	}
+
+	inputs := []struct {
+		name                string
+		responseCode        int
+		xmlResponse         string
+		expectAuthorization bool
+		expectError         bool
+		reportWith          metrics.ReportMetricsFn
+	}{
+		{
+			name:        "Test error case",
+			xmlResponse: "invalid",
+			expectError: true,
+		},
+		{
+			name:         "Test unauthorized",
+			responseCode: http.StatusTooManyRequests,
+			xmlResponse:  fake.GetLimitExceededResp(),
+		},
+		{
+			name:                "Test authorized",
+			responseCode:        http.StatusOK,
+			xmlResponse:         fake.GetAuthSuccess(),
+			expectAuthorization: true,
+		},
+		{
+			name:                "Test reporting",
+			responseCode:        http.StatusOK,
+			xmlResponse:         fake.GetAuthSuccess(),
+			expectAuthorization: true,
+			reportWith: func(serviceID string, l metrics.LatencyReport, s metrics.StatusReport) {
+				reported = true
+				wg.Done()
+			},
+		},
+	}
+	for _, input := range inputs {
+		t.Run(input.name, func(t *testing.T) {
+			httpClient := NewTestClient(t, func(req *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: input.responseCode,
+					Body:       ioutil.NopCloser(bytes.NewBufferString(input.xmlResponse)),
+					Header:     make(http.Header),
+				}
+			})
+
+			if input.reportWith != nil {
+				wg.Add(1)
+			}
+
+			threescaleClient := client.NewThreeScale(nil, httpClient)
+			b := DefaultBackend{ReportFn: input.reportWith}
+			resp, err := b.AuthRep(mockRequest, threescaleClient)
+
+			if err != nil && !input.expectError {
+				t.Error("unexpected error response")
+			}
+			if resp.Success != input.expectAuthorization {
+				t.Errorf("incorrect authorization result")
+			}
+
+			if input.reportWith != nil {
+				wg.Wait()
+				if !reported {
+					t.Errorf("expected reporting to have happened")
+				}
+			}
+			reported = false
+		})
+	}
+}
+
+// Mocking objects for HTTP tests
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+// Helper - Get a test client with transport overridden for mocking
+func NewTestClient(t *testing.T, fn RoundTripFunc) *http.Client {
+	t.Helper()
+	return &http.Client{
+		Transport: RoundTripFunc(fn),
+	}
+}

--- a/pkg/threescale/metrics/prometheus.go
+++ b/pkg/threescale/metrics/prometheus.go
@@ -42,6 +42,9 @@ type StatusReport struct {
 // Target is a legitimate target to report 3scale metrics from
 type Target string
 
+// ReportMetricsFn - function that defines requirements for reporting metrics around interactions between 3scale and the adapter
+type ReportMetricsFn func(serviceID string, l LatencyReport, s StatusReport)
+
 // Backend target should be used when reporting latency or status codes from 3scale backend
 const Backend Target = "Backend"
 

--- a/pkg/threescale/proxy_conf.go
+++ b/pkg/threescale/proxy_conf.go
@@ -360,7 +360,7 @@ func isExpired(currentTime time.Time, expiryTime time.Time) bool {
 }
 
 // GetFromRemote is used to fetch the proxy config from 3scale using the client
-func GetFromRemote(cfg *config.Params, c *sysC.ThreeScaleClient, report reportMetrics) (sysC.ProxyConfigElement, error) {
+func GetFromRemote(cfg *config.Params, c *sysC.ThreeScaleClient, report metrics.ReportMetricsFn) (sysC.ProxyConfigElement, error) {
 	log.Debugf("proxy config for service id %s is being fetching from 3scale", cfg.ServiceId)
 
 	start := time.Now()

--- a/pkg/threescale/proxy_conf_test.go
+++ b/pkg/threescale/proxy_conf_test.go
@@ -11,14 +11,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/3scale/3scale-istio-adapter/pkg/threescale/metrics"
-
-	"github.com/gogo/googleapis/google/rpc"
-
 	"github.com/3scale/3scale-go-client/fake"
 	pb "github.com/3scale/3scale-istio-adapter/config"
+	"github.com/3scale/3scale-istio-adapter/pkg/threescale/connectors/backend"
+	"github.com/3scale/3scale-istio-adapter/pkg/threescale/metrics"
 	"github.com/3scale/3scale-porta-go-client/client"
 	sysFake "github.com/3scale/3scale-porta-go-client/fake"
+	"github.com/gogo/googleapis/google/rpc"
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/api/mixer/adapter/model/v1beta1"
@@ -68,7 +67,7 @@ func TestProxyConfigCacheFlushing(t *testing.T) {
 	cfg := &pb.Params{ServiceId: "123", SystemUrl: "https://www.fake-system.3scale.net"}
 	cacheKey := pc.getCacheKeyFromCfg(cfg)
 	pc.set(cacheKey, proxyConf, cacheRefreshStore{})
-	conf := &AdapterConfig{systemCache: pc}
+	conf := &AdapterConfig{systemCache: pc, backend: backend.DefaultBackend{}}
 	c := &Threescale{client: httpClient, conf: conf}
 
 	inputs := []testInput{
@@ -210,7 +209,7 @@ func TestProxyConfigCacheRefreshing(t *testing.T) {
 	// Create cache manager
 	pc := NewProxyConfigCache(ttl, ttl-(time.Second*1), DefaultCacheUpdateRetries, 3)
 	proxyConf = unmarshalConfig(t)
-	conf := &AdapterConfig{systemCache: pc}
+	conf := &AdapterConfig{systemCache: pc, backend: backend.DefaultBackend{}}
 	c := &Threescale{client: httpClient, conf: conf}
 
 	//Pre-Populate the cache
@@ -361,7 +360,7 @@ func TestGetFromRemote(t *testing.T) {
 	inputs := []struct {
 		name       string
 		httpClient func() *http.Client
-		metricsFn  reportMetrics
+		metricsFn  metrics.ReportMetricsFn
 	}{
 		{
 			name: "Test metrics are reported success case",

--- a/pkg/threescale/threescale_integration_test.go
+++ b/pkg/threescale/threescale_integration_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/3scale/3scale-istio-adapter/pkg/threescale/connectors/backend"
+
 	"github.com/gogo/googleapis/google/rpc"
 
 	"github.com/3scale/3scale-go-client/fake"
@@ -209,7 +211,7 @@ func TestAuthorizationCheck(t *testing.T) {
 
 		s := integration.Scenario{
 			Setup: func() (ctx interface{}, err error) {
-				pServer, err := NewThreescale("3333", http.DefaultClient, &AdapterConfig{})
+				pServer, err := NewThreescale("3333", http.DefaultClient, &AdapterConfig{backend: backend.DefaultBackend{}})
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/threescale/threescale_test.go
+++ b/pkg/threescale/threescale_test.go
@@ -9,14 +9,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/googleapis/google/rpc"
-
-	"github.com/3scale/3scale-istio-adapter/pkg/threescale/metrics"
+	"github.com/3scale/3scale-istio-adapter/pkg/threescale/connectors/backend"
 
 	"github.com/3scale/3scale-go-client/fake"
 	pb "github.com/3scale/3scale-istio-adapter/config"
+	"github.com/3scale/3scale-istio-adapter/pkg/threescale/metrics"
 	sysFake "github.com/3scale/3scale-porta-go-client/fake"
+	"github.com/gogo/googleapis/google/rpc"
 	"github.com/gogo/protobuf/types"
+
 	"istio.io/istio/mixer/template/authorization"
 )
 
@@ -233,6 +234,7 @@ func TestHandleAuthorization(t *testing.T) {
 				client: httpClient,
 				conf: &AdapterConfig{
 					metricsReporter: reporter,
+					backend:         backend.DefaultBackend{},
 				},
 			}
 			result, _ := c.HandleAuthorization(ctx, r)
@@ -257,7 +259,7 @@ func TestHandleAuthorization(t *testing.T) {
 
 func Test_NewThreescale(t *testing.T) {
 	addr := "0"
-	threescaleConf := NewAdapterConfig(nil, nil, time.Minute)
+	threescaleConf := NewAdapterConfig(nil, nil, nil, time.Minute)
 	s, err := NewThreescale(addr, http.DefaultClient, threescaleConf)
 	if err != nil {
 		t.Errorf("Error running threescale server %#v", err)

--- a/pkg/threescale/types.go
+++ b/pkg/threescale/types.go
@@ -5,8 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/3scale/3scale-go-client/client"
-
+	"github.com/3scale/3scale-istio-adapter/pkg/threescale/connectors/backend"
 	prometheus "github.com/3scale/3scale-istio-adapter/pkg/threescale/metrics"
 	"google.golang.org/grpc"
 )
@@ -30,17 +29,6 @@ type Threescale struct {
 type AdapterConfig struct {
 	systemCache     *ProxyConfigCache
 	metricsReporter *prometheus.Reporter
+	backend         backend.Backend
 	keepAliveMaxAge time.Duration
-}
-
-// reportMetrics - function that defines requirements for reporting metrics around interactions between 3scale and the adapter
-type reportMetrics func(serviceID string, l prometheus.LatencyReport, s prometheus.StatusReport)
-
-type authRepFn func(auth client.TokenAuth, key string, svcID string, params client.AuthRepParams, ext map[string]string) (client.ApiResponse, error)
-
-type authRepRequest struct {
-	svcID   string
-	authKey string
-	params  client.AuthRepParams
-	auth    client.TokenAuth
 }


### PR DESCRIPTION
This change decouples the backend logic from the core handling logic in the adapter and it sets the way for breaking out a caching enabling library for backend.

@unleashed - mind taking a look? I would like to merge this in isolation if possible and build on top of it for the caching implementation.