### PR TITLE
Changes to k3s environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ integration_coverage: integration ## Runs integration tests and generates a html
 local.cluster.environment: local.cluster.up local.install-istio local.install-adapter local.install-httpbin ## Starts a k3s cluster with istio installed alongside the adapter and httpbin sample app
 
 .PHONY: local.cluster.up
-local.cluster.up: ## Starts a k3s cluster
+local.cluster.up: ## Starts a k3s cluster using istio version set in ${ISTIO_VERSION}. Supports only versions of less than 1.5.0
 	docker-compose -f $(PROJECT_PATH)/scripts/local-cluster/docker-compose.yaml up -d
-	sleep 5
+	sleep 10
 	kubectl --kubeconfig $(PROJECT_PATH)/scripts/local-cluster/kubeconfig.yaml wait --for=condition=available --timeout=60s deployment/coredns -n kube-system
 
 .PHONY: local.cluster.clean

--- a/istio/samples/httpbin/httpbin.yaml
+++ b/istio/samples/httpbin/httpbin.yaml
@@ -29,12 +29,15 @@ spec:
   selector:
     app: httpbin
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: httpbin
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
   template:
     metadata:
       labels:

--- a/scripts/istio-utils.sh
+++ b/scripts/istio-utils.sh
@@ -14,11 +14,6 @@ sample_dir="${root_dir}"/istio/samples
 # If parsing fails, default to setting to the latest version.
 function get_istio_version() {
     if [[ "x${ISTIO_VERSION}" = "x" ]] ; then
-        # not using regex here because of some compatibility issues across different OS
-        ISTIO_VERSION=$(grep -A 1 "istio.io/istio" ${root_dir}/Gopkg.toml | grep "version" | cut -d'"' -f 2 | tr -d "=<>~^")
-    fi
-
-    if [[ "x${ISTIO_VERSION}" = "x" ]] ; then
       echo "Unable to parse Istio version from dependencies - attempting to use latest version"
       ISTIO_VERSION=$(curl -L -s https://api.github.com/repos/istio/istio/releases/latest | \
                       grep tag_name | sed "s/ *\"tag_name\": *\"\\(.*\\)\",*/\\1/")
@@ -29,6 +24,9 @@ function get_istio_version() {
       exit;
     fi
 
+    # to-do (pgough) as of >= 1.5 mixer will not be deployed by default so down the road we need to consider how we will
+    # handle this. In all likelihood, this will require a rework and an option to use with/without wasm etc
+    # Parking for now. Needs revisiting. Supporting only < 1.5
     printf ${ISTIO_VERSION}
 }
 
@@ -48,7 +46,7 @@ function get_istio() {
     URL="https://github.com/istio/istio/releases/download/${version}/istio-${version}-${OSEXT}.tar.gz"
     if ! [[ -d ${output_dir}/${NAME} ]]; then
       printf "Downloading %s from %s ..." "$NAME" "$URL"
-      mkdir - p "${output_dir}" && cd "${output_dir}" && curl -L "$URL" | tar xz
+      mkdir -p "${output_dir}" && cd "${output_dir}" && curl -L "$URL" | tar xz
     fi
 }
 

--- a/scripts/local-cluster/docker-compose.yaml
+++ b/scripts/local-cluster/docker-compose.yaml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   server:
-    image: rancher/k3s:v0.6.1
+    image: rancher/k3s:v1.17.4-k3s1
     command: server --disable-agent --no-deploy traefik
     environment:
       - K3S_CLUSTER_SECRET=secret
@@ -16,7 +16,7 @@ services:
       - 6443:6443
 
   node:
-    image: rancher/k3s:v0.6.1
+    image: rancher/k3s:v1.17.4-k3s1
     tmpfs:
       - /run
       - /var/run


### PR DESCRIPTION
Fixes #131 

@unleashed I've tested this against 1.4.6 istio. As you might see from some of the commit changes its not really feasible to keep this compatible with all versions of istio anymore because of the breaking changes and the different flags in helm.

I've made a best effort fix for now that will suit our needs in the mean time and we can revisit if its either not good enough or when things upstream stabilise a bit.