### PR TITLE
Update RPC return status

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   revision = "8b3f1e0858ea5890389def65da3dcb063e606332"
 
 [[projects]]
-  digest = "1:607f43c21ada48da1e86a81477cbd44cbd88e1c9fd054026075c1b6010603734"
+  digest = "1:cf1dd494a482c6cce8ab959a60bad99b52a44c7f9abbc9029a741330433cb2cf"
   name = "github.com/3scale/3scale-go-client"
   packages = [
     "threescale",
@@ -26,7 +26,7 @@
     "threescale/internal",
   ]
   pruneopts = "NUT"
-  revision = "79ec8a9626e243cb73066960cc902a98fe70fde4"
+  revision = "65caa338b3b939f9541f5145c61da341d7afb1a5"
 
 [[projects]]
   digest = "1:be660b3d469d79ce10dca0ac101e0b37c9fe80803880950afa2cc85825b93b63"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,7 +18,7 @@
 
 [[constraint]]
   name = "github.com/3scale/3scale-go-client"
-  revision = "79ec8a9626e243cb73066960cc902a98fe70fde4"
+  revision = "65caa338b3b939f9541f5145c61da341d7afb1a5"
 
 [[constraint]]
   name = "github.com/3scale/3scale-porta-go-client"

--- a/pkg/threescale/authorizer/authorizer.go
+++ b/pkg/threescale/authorizer/authorizer.go
@@ -62,8 +62,8 @@ type BackendRequest struct {
 // BackendResponse contains the result of an Auth/AuthRep request
 type BackendResponse struct {
 	Authorized bool
-	// RejectedReason should* be set in cases where Authorized is false
-	RejectedReason string
+	// ErrorCode should be set in cases where Authorized is false
+	ErrorCode string
 }
 
 // BackendTransaction contains the metrics and end user auth required to make an Auth/AuthRep request to apisonator
@@ -169,7 +169,7 @@ func (m Manager) AuthRep(backendURL string, request BackendRequest) (*BackendRes
 		return nil, fmt.Errorf("error calling AuthRep - %s", err)
 	}
 
-	return &BackendResponse{Authorized: res.Authorized, RejectedReason: res.ErrorCode}, nil
+	return &BackendResponse{Authorized: res.Authorized, ErrorCode: res.ErrorCode}, nil
 }
 
 func (m Manager) fetchSystemConfigFromCache(systemURL string, request SystemRequest) (client.ProxyConfig, error) {

--- a/pkg/threescale/authorizer/authorizer_test.go
+++ b/pkg/threescale/authorizer/authorizer_test.go
@@ -505,7 +505,6 @@ func TestBackendRequest_ToAPIRequest(t *testing.T) {
 					UserID:   "maybe",
 					UserKey:  "",
 				},
-				Timestamp: "",
 			},
 		},
 	}

--- a/pkg/threescale/threescale_integration_test.go
+++ b/pkg/threescale/threescale_integration_test.go
@@ -315,8 +315,8 @@ spec:
 					},
 				},
 				withAuthResponse: &authorizer.BackendResponse{
-					Authorized:     false,
-					RejectedReason: "should overwrite",
+					Authorized: false,
+					ErrorCode:  "should overwrite",
 				},
 			},
 			expect: authenticatedSuccess,
@@ -352,8 +352,8 @@ spec:
 					},
 				},
 				withAuthResponse: &authorizer.BackendResponse{
-					Authorized:     false,
-					RejectedReason: "should overwrite",
+					Authorized: false,
+					ErrorCode:  "should overwrite",
 				},
 			},
 			expect: authenticatedSuccess,
@@ -389,8 +389,8 @@ spec:
 					},
 				},
 				withAuthResponse: &authorizer.BackendResponse{
-					Authorized:     false,
-					RejectedReason: "should overwrite",
+					Authorized: false,
+					ErrorCode:  "should overwrite",
 				},
 			},
 			expect: authenticatedSuccess,
@@ -426,8 +426,8 @@ spec:
 					},
 				},
 				withAuthResponse: &authorizer.BackendResponse{
-					Authorized:     false,
-					RejectedReason: "should overwrite",
+					Authorized: false,
+					ErrorCode:  "should overwrite",
 				},
 			},
 			expect: authenticatedSuccess,
@@ -463,8 +463,8 @@ spec:
 					},
 				},
 				withAuthResponse: &authorizer.BackendResponse{
-					Authorized:     false,
-					RejectedReason: "should not overwrite",
+					Authorized: false,
+					ErrorCode:  "should not overwrite",
 				},
 			},
 			expect: generatedExpectedError(t, rpc.UNAUTHENTICATED, errNoCredentials.Error()),
@@ -501,8 +501,8 @@ spec:
 					},
 				},
 				withAuthResponse: &authorizer.BackendResponse{
-					Authorized:     false,
-					RejectedReason: "should overwrite",
+					Authorized: false,
+					ErrorCode:  "should overwrite",
 				},
 			},
 			expect: authenticatedSuccess,
@@ -539,11 +539,11 @@ spec:
 					},
 				},
 				withAuthResponse: &authorizer.BackendResponse{
-					Authorized:     false,
-					RejectedReason: "should not overwrite",
+					Authorized: false,
+					ErrorCode:  "should not overwrite",
 				},
 			},
-			expect: generatedExpectedError(t, rpc.PERMISSION_DENIED, "should not overwrite"),
+			expect: generatedExpectedError(t, rpc.UNKNOWN, "should not overwrite"),
 		},
 	}
 

--- a/pkg/threescale/threescale_test.go
+++ b/pkg/threescale/threescale_test.go
@@ -106,7 +106,7 @@ func TestHandleAuthorization(t *testing.T) {
 					Authorized: false,
 				},
 			},
-			expectStatus: int32(rpc.PERMISSION_DENIED),
+			expectStatus: int32(rpc.UNKNOWN),
 		},
 		{
 			name: "Test override with internal DNS",
@@ -153,25 +153,6 @@ func TestHandleAuthorization(t *testing.T) {
 			},
 			expectStatus: int32(rpc.OK),
 		},
-		//{
-		//	name: "Test override with internal DNS",
-		//	params: pb.Params{
-		//		ServiceId:   "internal-svc",
-		//		SystemUrl:   "https://www.fake-system.3scale.net",
-		//		AccessToken: "happy-path",
-		//		BackendUrl:  "http://" + internalBackendUrl,
-		//	},
-		//	expectStatus: int32(rpc.OK),
-		//	template: authorization.InstanceMsg{
-		//		Action: &authorization.ActionMsg{
-		//			Method: "get",
-		//			Path:   "/",
-		//		},
-		//		Subject: &authorization.SubjectMsg{
-		//			User: "secret",
-		//		},
-		//	},
-		//},
 	}
 	for _, input := range inputs {
 		t.Run(input.name, func(t *testing.T) {


### PR DESCRIPTION
Pulls in latest code in the client to correctly convert error code to http status before transforming to rpc code

Fixes #135 
