### PR TITLE
Change default header names for authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ spec:
   template: threescale-authorization
   params:
     subject:
-      user: request.query_params["user_key"] | request.headers["user-key"] | ""
+      user: request.query_params["user_key"] | request.headers["user_key"] | ""
     action:
       path: request.url_path
       method: request.method | "get"
@@ -168,8 +168,8 @@ spec:
   template: threescale-authorization
   params:
     subject:
-        app_id: request.query_params["app_id"] | request.headers["app-id"] | ""
-        app_key: request.query_params["app_key"] | request.headers["app-key"] | ""
+        app_id: request.query_params["app_id"] | request.headers["app_id"] | ""
+        app_key: request.query_params["app_key"] | request.headers["app_key"] | ""
     action:
       path: request.url_path
       method: request.method | "get"
@@ -191,7 +191,7 @@ spec:
   template: threescale-authorization
   params:
     subject:
-        app_key: request.query_params["app_key"] | request.headers["app-key"] | ""
+        app_key: request.query_params["app_key"] | request.headers["app_key"] | ""
         client_id: request.auth.claims["azp"] | ""
     action:
       path: request.url_path
@@ -235,10 +235,10 @@ spec:
   template: threescale-authorization
   params:
     subject:
-      user: request.query_params["user_key"] | request.headers["user-key"] | ""
+      user: request.query_params["user_key"] | request.headers["user_key"] | ""
       properties:
-        app_id: request.query_params["app_id"] | request.headers["app-id"] | ""
-        app_key: request.query_params["app_key"] | request.headers["app-key"] | ""
+        app_id: request.query_params["app_id"] | request.headers["app_id"] | ""
+        app_key: request.query_params["app_key"] | request.headers["app_key"] | ""
     action:
       path: request.url_path
       method: request.method | "get"

--- a/istio/threescale-adapter-config.yaml
+++ b/istio/threescale-adapter-config.yaml
@@ -22,10 +22,10 @@ spec:
   template: threescale-authorization
   params:
     subject:
-      user: request.query_params["user_key"] | request.headers["x-user-key"] | ""
+      user: request.query_params["user_key"] | request.headers["user_key"] | ""
       properties:
-        app_id: request.query_params["app_id"] | request.headers["x-app-id"] | ""
-        app_key: request.query_params["app_key"] | request.headers["x-app-key"] | ""
+        app_id: request.query_params["app_id"] | request.headers["app_id"] | ""
+        app_key: request.query_params["app_key"] | request.headers["app_key"] | ""
         client_id: request.auth.claims["azp"] | ""
     action:
       path: request.url_path

--- a/pkg/kubernetes/threescale.go
+++ b/pkg/kubernetes/threescale.go
@@ -28,11 +28,11 @@ const (
 	defaultThreescaleOIDCLabel   = threescale.OIDCAttributeKey
 
 	//DefaultApiKeyAttribute string for a 3scale adapter instance - Api Key pattern
-	DefaultApiKeyAttribute = `request.query_params["user_key"] | request.headers["x-user-key"] | ""`
+	DefaultApiKeyAttribute = `request.query_params["user_key"] | request.headers["user_key"] | ""`
 	//DefaultAppIDAttribute string for a 3scale adapter instance - App ID pattern
-	DefaultAppIDAttribute = `request.query_params["app_id"] | request.headers["app-id"] | ""`
+	DefaultAppIDAttribute = `request.query_params["app_id"] | request.headers["app_id"] | ""`
 	//DefaultAppKeyAttribute string for a 3scale adapter instance - App ID/OIDC pattern
-	DefaultAppKeyAttribute = `request.query_params["app_key"] | request.headers["app-key"] | ""`
+	DefaultAppKeyAttribute = `request.query_params["app_key"] | request.headers["app_key"] | ""`
 	//DefaultOIDCAttribute string for a 3scale adapter instance - OIDC pattern
 	DefaultOIDCAttribute = `request.auth.claims["azp"] | ""`
 )

--- a/pkg/kubernetes/threescale_test.go
+++ b/pkg/kubernetes/threescale_test.go
@@ -101,7 +101,7 @@ func TestNewApiKeyInstance(t *testing.T) {
     path: request.url_path
     service: destination.labels["service-mesh.3scale.net/service-id"] | ""
   subject:
-    user: request.query_params["user_key"] | request.headers["x-user-key"] | ""
+    user: request.query_params["user_key"] | request.headers["user_key"] | ""
 template: threescale-authorization`
 	instance := NewApiKeyInstance(DefaultApiKeyAttribute)
 	b, err := json.MarshalIndent(instance, "", "  ")
@@ -127,8 +127,8 @@ func TestNewAppIDAppKeyInstance(t *testing.T) {
     service: destination.labels["service-mesh.3scale.net/service-id"] | ""
   subject:
     properties:
-      app_id: request.query_params["app_id"] | request.headers["app-id"] | ""
-      app_key: request.query_params["app_key"] | request.headers["app-key"] | ""
+      app_id: request.query_params["app_id"] | request.headers["app_id"] | ""
+      app_key: request.query_params["app_key"] | request.headers["app_key"] | ""
 template: threescale-authorization`
 	instance := NewAppIDAppKeyInstance(DefaultAppIDAttribute, DefaultAppKeyAttribute)
 	b, err := json.MarshalIndent(instance, "", "  ")

--- a/pkg/threescale/threescale_integration_test.go
+++ b/pkg/threescale/threescale_integration_test.go
@@ -104,7 +104,7 @@ func TestAuthorizationCheck(t *testing.T) {
 						"context.reporter.kind": "inbound",
 						"request.url_path":      "/",
 						"request.method":        "get",
-						"request.headers":       map[string]string{"x-user-key": validAuth},
+						"request.headers":       map[string]string{"user_key": validAuth},
 						"destination.labels": map[string]string{
 							"service-mesh.3scale.net/credentials": "threescale",
 							"service-mesh.3scale.net/service-id":  "any",
@@ -137,7 +137,7 @@ func TestAuthorizationCheck(t *testing.T) {
 						"context.reporter.kind": "inbound",
 						"request.url_path":      "/",
 						"request.method":        "get",
-						"request.headers":       map[string]string{"x-user-key": validAuth},
+						"request.headers":       map[string]string{"user_key": validAuth},
 						"destination.labels": map[string]string{
 							"service-mesh.3scale.net/credentials": "threescale",
 							"service-mesh.3scale.net/service-id":  "any",
@@ -183,7 +183,7 @@ spec:
 						"context.reporter.kind": "inbound",
 						"request.url_path":      "/",
 						"request.method":        "get",
-						"request.headers":       map[string]string{"x-user-key": validAuth},
+						"request.headers":       map[string]string{"user_key": validAuth},
 						"destination.labels": map[string]string{
 							"service-mesh.3scale.net/credentials": "threescale",
 							"service-mesh.3scale.net/service-id":  "any",
@@ -229,7 +229,7 @@ spec:
 						"context.reporter.kind": "inbound",
 						"request.url_path":      "/",
 						"request.method":        "get",
-						"request.headers":       map[string]string{"x-user-key": validAuth},
+						"request.headers":       map[string]string{"user_key": validAuth},
 						"destination.labels": map[string]string{
 							"service-mesh.3scale.net/credentials": "threescale",
 						},
@@ -292,7 +292,7 @@ spec:
 					Attrs: map[string]interface{}{
 						"context.reporter.kind": "inbound",
 						"request.url_path":      "/thispath",
-						"request.headers":       map[string]string{"x-user-key": validAuth},
+						"request.headers":       map[string]string{"user_key": validAuth},
 						"request.method":        "get",
 						"destination.labels": map[string]string{
 							"service-mesh.3scale.net/credentials": "threescale",
@@ -366,7 +366,7 @@ spec:
 					Attrs: map[string]interface{}{
 						"context.reporter.kind": "inbound",
 						"request.url_path":      "/thispath",
-						"request.headers":       map[string]string{"app-id": validAuth, "app-key": "secret"},
+						"request.headers":       map[string]string{"app_id": validAuth, "app_key": "secret"},
 						"request.method":        "get",
 						"destination.labels": map[string]string{
 							"service-mesh.3scale.net/credentials": "threescale",

--- a/testdata/threescale-adapter-config.yaml
+++ b/testdata/threescale-adapter-config.yaml
@@ -13,10 +13,10 @@ spec:
       service: destination.labels["service-mesh.3scale.net/service-id"] | ""
     subject:
       properties:
-        app_id: request.query_params["app_id"] | request.headers["app-id"] | ""
-        app_key: request.query_params["app_key"] | request.headers["app-key"] | ""
+        app_id: request.query_params["app_id"] | request.headers["app_id"] | ""
+        app_key: request.query_params["app_key"] | request.headers["app_key"] | ""
         client_id: request.auth.claims["azp"] | ""
-      user: request.query_params["user_key"] | request.headers["x-user-key"] | ""
+      user: request.query_params["user_key"] | request.headers["user_key"] | ""
   template: threescale-authorization
 ---
 apiVersion: config.istio.io/v1alpha2


### PR DESCRIPTION
* Change the header names used for authorization to be in sync with default values set by Porta and APIcast.
   * Update `README.md` with new values.
   * Update `istio/threescale-adapter-config.yaml` with new values.
   * Update tests.
Fixes #137 