### PR TITLE
Enable rejection reason header extension in backend

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   revision = "8b3f1e0858ea5890389def65da3dcb063e606332"
 
 [[projects]]
-  digest = "1:cf1dd494a482c6cce8ab959a60bad99b52a44c7f9abbc9029a741330433cb2cf"
+  digest = "1:e5d7ed7b8c33904bc7a4c7b8b979dc3f063919ce81adc3b79a2841b2587999e2"
   name = "github.com/3scale/3scale-go-client"
   packages = [
     "threescale",
@@ -26,7 +26,7 @@
     "threescale/internal",
   ]
   pruneopts = "NUT"
-  revision = "65caa338b3b939f9541f5145c61da341d7afb1a5"
+  revision = "527d0856a00f247b90f1febfae979d06a6d228de"
 
 [[projects]]
   digest = "1:be660b3d469d79ce10dca0ac101e0b37c9fe80803880950afa2cc85825b93b63"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,7 +18,7 @@
 
 [[constraint]]
   name = "github.com/3scale/3scale-go-client"
-  revision = "65caa338b3b939f9541f5145c61da341d7afb1a5"
+  revision = "527d0856a00f247b90f1febfae979d06a6d228de"
 
 [[constraint]]
   name = "github.com/3scale/3scale-porta-go-client"

--- a/pkg/threescale/authorizer/authorizer_test.go
+++ b/pkg/threescale/authorizer/authorizer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/3scale/3scale-authorizer/pkg/system/v1/cache"
 	"github.com/3scale/3scale-go-client/threescale"
 	"github.com/3scale/3scale-go-client/threescale/api"
+	http2 "github.com/3scale/3scale-go-client/threescale/http"
 	"github.com/3scale/3scale-porta-go-client/client"
 )
 
@@ -493,8 +494,10 @@ func TestBackendRequest_ToAPIRequest(t *testing.T) {
 			Type:  api.AuthType("any"),
 			Value: "any",
 		},
-		Extensions: nil,
-		Service:    "any",
+		Extensions: api.Extensions{
+			http2.RejectionReasonHeaderExtension: "1",
+		},
+		Service: "any",
 		Transactions: []api.Transaction{
 			{
 				Metrics: api.Metrics{"hits": 5},


### PR DESCRIPTION
The real fix for #135 - see https://github.com/3scale/apisonator/issues/211 for context