### PR TITLE
adapter: Return NOT_FOUND (404) when no matching mapping rules exist

### DIFF
--- a/pkg/threescale/threescale.go
+++ b/pkg/threescale/threescale.go
@@ -215,7 +215,7 @@ func (s *Threescale) validateBackendRequest(request authorizer.BackendRequest) (
 		}
 
 		if len(transaction.Metrics) == 0 {
-			return status.WithPermissionDenied, errNoMappingRule
+			return status.WithNotFound, errNoMappingRule
 		}
 	}
 	return nil, nil

--- a/pkg/threescale/threescale_integration_test.go
+++ b/pkg/threescale/threescale_integration_test.go
@@ -126,7 +126,7 @@ func TestAuthorizationCheck(t *testing.T) {
 				},
 				withSystemErr: nil,
 			},
-			expect: generatedExpectedError(t, rpc.PERMISSION_DENIED, "no matching mapping rule for request"),
+			expect: generatedExpectedError(t, rpc.NOT_FOUND, "no matching mapping rule for request"),
 		},
 		{
 			name: "Test failure when no access token set in handler",


### PR DESCRIPTION
Closes #141 