### PR TITLE
Fixes 148

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   revision = "8b3f1e0858ea5890389def65da3dcb063e606332"
 
 [[projects]]
-  digest = "1:e5d7ed7b8c33904bc7a4c7b8b979dc3f063919ce81adc3b79a2841b2587999e2"
+  digest = "1:785026af48559cb96056b851f6c0e5776788c2aa36747c84fbe5ca3af7f1b39e"
   name = "github.com/3scale/3scale-go-client"
   packages = [
     "threescale",
@@ -26,7 +26,7 @@
     "threescale/internal",
   ]
   pruneopts = "NUT"
-  revision = "527d0856a00f247b90f1febfae979d06a6d228de"
+  revision = "59f1bbdf5147f20e8e04e81d8d60b7dc196e877f"
 
 [[projects]]
   digest = "1:be660b3d469d79ce10dca0ac101e0b37c9fe80803880950afa2cc85825b93b63"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,7 +18,7 @@
 
 [[constraint]]
   name = "github.com/3scale/3scale-go-client"
-  revision = "527d0856a00f247b90f1febfae979d06a6d228de"
+  revision = "59f1bbdf5147f20e8e04e81d8d60b7dc196e877f"
 
 [[constraint]]
   name = "github.com/3scale/3scale-porta-go-client"

--- a/pkg/threescale/authorizer/authorizer.go
+++ b/pkg/threescale/authorizer/authorizer.go
@@ -66,6 +66,7 @@ type BackendResponse struct {
 	ErrorCode  string
 	// RejectedReason should* be set in cases where Authorized is false
 	RejectedReason string
+	RawResponse    interface{}
 }
 
 // BackendTransaction contains the metrics and end user auth required to make an Auth/AuthRep request to apisonator
@@ -168,13 +169,21 @@ func (m Manager) AuthRep(backendURL string, request BackendRequest) (*BackendRes
 
 	res, err := client.AuthRep(*req)
 	if err != nil {
-		return nil, fmt.Errorf("error calling AuthRep - %s", err)
+		var rawResponse interface{}
+		if res != nil {
+			rawResponse = res.RawResponse
+		}
+		return &BackendResponse{
+			Authorized:  false,
+			RawResponse: rawResponse,
+		}, fmt.Errorf("error calling AuthRep - %s", err)
 	}
 
 	return &BackendResponse{
 		Authorized:     res.Authorized,
 		ErrorCode:      res.ErrorCode,
 		RejectedReason: res.RejectionReason,
+		RawResponse:    res.RawResponse,
 	}, nil
 }
 

--- a/pkg/threescale/threescale_test.go
+++ b/pkg/threescale/threescale_test.go
@@ -220,5 +220,5 @@ func (m mockAuthorizer) AuthRep(backendURL string, request authorizer.BackendReq
 	if params.UserKey == "VALID" || params.AppID == "VALID" {
 		m.withAuthResponse.Authorized = true
 	}
-	return m.withAuthResponse, m.withSystemErr
+	return m.withAuthResponse, m.withBackendErr
 }


### PR DESCRIPTION
Pulls in the new client to allow us to add better context and mapping to 5xx errors from backend.

Fixes #148.