### PR TITLE
Add support for ''last' and 'position' fields in proxy rules from 3scale porta

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -29,11 +29,11 @@
   revision = "527d0856a00f247b90f1febfae979d06a6d228de"
 
 [[projects]]
-  digest = "1:be660b3d469d79ce10dca0ac101e0b37c9fe80803880950afa2cc85825b93b63"
+  digest = "1:9c5eb3708d92f87a0490935256c0d198ec74b234de38cff4d6df44d4d4cc8f3f"
   name = "github.com/3scale/3scale-porta-go-client"
   packages = ["client"]
   pruneopts = "NUT"
-  revision = "f6fbb21026d4577eb42c1186be300f01c859b686"
+  revision = "d87f43da14bc4a70e5c0ecb736f7d0f4e4c25b00"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 [[constraint]]
   name = "github.com/3scale/3scale-porta-go-client"
-  revision = "f6fbb21026d4577eb42c1186be300f01c859b686"
+  revision = "d87f43da14bc4a70e5c0ecb736f7d0f4e4c25b00"
 
 [[constraint]]
   name = "github.com/3scale/3scale-authorizer"

--- a/pkg/threescale/threescale.go
+++ b/pkg/threescale/threescale.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -239,10 +240,19 @@ func (s *Threescale) convertAuthResponse(resp *authorizer.BackendResponse, resul
 func generateMetrics(path string, method string, conf system.ProxyConfig) api.Metrics {
 	metrics := make(api.Metrics)
 
+	// sort proxy rules based on Position field to establish priority
+	sort.Slice(conf.Content.Proxy.ProxyRules, func(i, j int) bool {
+		return conf.Content.Proxy.ProxyRules[i].Position < conf.Content.Proxy.ProxyRules[j].Position
+	})
+
 	for _, pr := range conf.Content.Proxy.ProxyRules {
 		if match, err := regexp.MatchString(pr.Pattern, path); err == nil {
 			if match && strings.ToUpper(pr.HTTPMethod) == strings.ToUpper(method) {
 				metrics.Add(pr.MetricSystemName, int(pr.Delta))
+				// stop matching if this rule has been marked as Last
+				if pr.Last {
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Porta recently added support for prioritising metrics and adding a flag to stop processing metrics using the `last` field.

This change pulls in updates to the http client and cuts short the processing of mapping rules on incoming requests when the `last` field is set to true

Fixes #142