### PR TITLE
dep: Direct logs to istio logger

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,11 +120,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
+  digest = "1:e0f096f9332ad5f84341de82db69fd098864b17c668333a1fbbffd1b846dcc2b"
   name = "github.com/golang/glog"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+  revision = "d7cfb6fa2ccda15565f68f204d68907c80a5c977"
+  source = "github.com/istio/glog"
 
 [[projects]]
   digest = "1:5ae5b54d7cd695bafa92bf426b7c3d046f907260ec0fcb4fe5c368d937597c00"
@@ -1134,6 +1135,7 @@
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/proto",
     "github.com/gogo/protobuf/types",
+    "github.com/golang/glog",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/client_golang/prometheus/testutil",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,4 +1,10 @@
 # Refer to https://golang.github.io/dep/docs/Gopkg.toml.html for details
+required = ["github.com/golang/glog"]
+
+[[override]]
+  name = "github.com/golang/glog"
+  source = "github.com/istio/glog"
+  revision = "d7cfb6fa2ccda15565f68f204d68907c80a5c977"
 
 [[override]]
   name = "istio.io/api"


### PR DESCRIPTION
Fixes #117 

Output of `--help` before change:

```
GO111MODULE=off go run cmd/cli/main.go -help
Usage of /var/folders/h1/wh30j9tj5vl7j_xmmvw8q28c0000gn/T/go-build463269828/b001/exe/main:
  -alsologtostderr
    	log to standard error as well as files
  -auth int
    	3scale authentication pattern to use. 1=ApiKey, 2=AppID, 3=OpenID Connect. Default template supports a hybrid if none provided
  -backend-url string
    	The 3scale backend url
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -logtostderr
    	log to standard error instead of files
  -n string
    	The namespace which the manifests should be generated for. Default 'istio-system' (short) (default "istio-system")
  -name string
    	Unique name for this (url,token) pair (required)
  -namespace string
    	The namespace which the manifests should be generated for. Default 'istio-system' (default "istio-system")
  -o string
    	File to output templates. Prints to stdout if none provided (short)
  -output string
    	File to output templates. Prints to stdout if none provided
  -service string
    	The ID of the 3scale service. If set the generated configuration will apply to this service only.
  -stderrthreshold value
    	logs at or above this threshold go to stderr
  -t string
    	3scale access token (required) (short)
  -token string
    	3scale access token (required)
  -u string
    	The 3scale admin portal URL (required) (short)
  -url string
    	The 3scale admin portal URL (required)
  -v value
    	log level for V logs
  -version
    	Prints CLI version
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
exit status 2
```


Output after: 
```
GO111MODULE=off go run cmd/cli/main.go -help
Usage of /var/folders/h1/wh30j9tj5vl7j_xmmvw8q28c0000gn/T/go-build335464621/b001/exe/main:
  -auth int
    	3scale authentication pattern to use. 1=ApiKey, 2=AppID, 3=OpenID Connect. Default template supports a hybrid if none provided
  -backend-url string
    	The 3scale backend url
  -n string
    	The namespace which the manifests should be generated for. Default 'istio-system' (short) (default "istio-system")
  -name string
    	Unique name for this (url,token) pair (required)
  -namespace string
    	The namespace which the manifests should be generated for. Default 'istio-system' (default "istio-system")
  -o string
    	File to output templates. Prints to stdout if none provided (short)
  -output string
    	File to output templates. Prints to stdout if none provided
  -service string
    	The ID of the 3scale service. If set the generated configuration will apply to this service only.
  -t string
    	3scale access token (required) (short)
  -token string
    	3scale access token (required)
  -u string
    	The 3scale admin portal URL (required) (short)
  -url string
    	The 3scale admin portal URL (required)
  -version
    	Prints CLI version
exit status 2
```