### PR TITLE
Support graceful shutdown of the adapter and caches

### DIFF
--- a/pkg/threescale/authorizer/authorizer.go
+++ b/pkg/threescale/authorizer/authorizer.go
@@ -17,6 +17,7 @@ import (
 type Authorizer interface {
 	GetSystemConfiguration(systemURL string, request SystemRequest) (client.ProxyConfig, error)
 	AuthRep(backendURL string, request BackendRequest) (*BackendResponse, error)
+	Shutdown()
 }
 
 // Manager manages connections and interactions between the adapter and 3scale (system and backend)
@@ -190,6 +191,11 @@ func (m Manager) AuthRep(backendURL string, request BackendRequest) (*BackendRes
 	}
 
 	return m.cachedAuthRep(backendURL, request)
+}
+
+func (m Manager) Shutdown() {
+	close(m.stopFlush)
+	close(m.systemCache.stopRefreshingTask)
 }
 
 func (m Manager) passthroughAuthRep(backendURL string, request BackendRequest) (*BackendResponse, error) {

--- a/pkg/threescale/threescale_test.go
+++ b/pkg/threescale/threescale_test.go
@@ -294,3 +294,5 @@ func (m mockAuthorizer) AuthRep(backendURL string, request authorizer.BackendReq
 	}
 	return m.withAuthResponse, m.withBackendErr
 }
+
+func (m mockAuthorizer) Shutdown() {}


### PR DESCRIPTION
On reciept of certain signals, it is important to exit graceful and
ensure that we report any state in the backend cache to 3scale.

Includes general cleanup of `main`