### PR TITLE
Fix CVEs in golang.org/x/text and golang.org/x/crypto

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -631,13 +631,15 @@
   revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
 
 [[projects]]
-  digest = "1:e7071ed636b5422cc51c0e3a6cebc229d6c9fffc528814b519a980641422d619"
+  digest = "1:fa940333c48808b0d86ef21f412ffcfd0e5084a82f13905c028a404803b1908f"
   name = "golang.org/x/text"
   packages = [
     "collate",
     "collate/build",
     "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -650,8 +652,8 @@
     "unicode/rangetable",
   ]
   pruneopts = "NUT"
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
+  revision = "23ae387dee1f90d29a23c0e87ee0b46038fbed0e"
+  version = "v0.3.3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -580,12 +580,11 @@
   version = "v1.9.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
+  digest = "1:ad2bf20798504fbde0c5bdf5ee83d3354fb101d32c5b2267f811c1958b91b0ab"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = "NUT"
-  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
+  revision = "bac4c82f69751a6dd76e702d54b3ceb88adab236"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,6 +4,10 @@
   name = "istio.io/api"
   version = "=1.1.8"
 
+[[override]]
+  name = "golang.org/x/crypto"
+  revision = "bac4c82f69751a6dd76e702d54b3ceb88adab236"
+
 [[constraint]]
   name = "github.com/gogo/protobuf"
   version = "1.1.1"


### PR DESCRIPTION
This fixes [MAISTRA-1679](https://issues.redhat.com/browse/MAISTRA-1679) and [MAISTRA-1680](https://issues.redhat.com/browse/MAISTRA-1680) by updating the two affected packages.