### PR TITLE
Add root CA and client certificate support

### DIFF
--- a/cmd/server/README.md
+++ b/cmd/server/README.md
@@ -20,6 +20,9 @@ configuring the following environment variables:
 | CACHE_ENTRIES_MAX     | Max number of items that can be stored in the cache at any time. Set to 0 to disable caching       | 1000    |
 | CACHE_REFRESH_RETRIES | Sets the number of times unreachable hosts will be retried during a cache update loop              | 1       |
 | ALLOW_INSECURE_CONN   | Allow to skip certificate verification when calling 3scale API's. Enabling is not recommended      | false   |
+| ROOT_CA               | Path to root CA file using PEM format                                                              | N/A     |
+| CLIENT_CERT           | Path to client certificate (public key) using PEM format (requires CLIENT_KEY)                     | N/A     |
+| CLIENT_KEY            | Path to client key (private key) using PEM format (requires CLIENT_CERT)                           | N/A     |
 | CLIENT_TIMEOUT_SECONDS| Sets the number of seconds to wait before terminating requests to 3scale System and Backend        | 10      |
 | GRPC_CONN_MAX_SECONDS | Sets the maximum amount of seconds (+/-10% jitter) a connection may exist before it will be closed | 60      |
 | USE_CACHED_BACKEND    | If true, attempt to create an in-memory apisonator cache for authorization requests                | false   |

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -64,6 +64,21 @@ spec:
             configMapKeyRef:
               key: client.allow_insecure_connections
               name: 3scale-istio-adapter-conf
+        - name: ROOT_CA
+          valueFrom:
+            configMapKeyRef:
+              key: client.root_ca
+              name: 3scale-istio-adapter-conf
+        - name: CLIENT_CERT
+          valueFrom:
+            configMapKeyRef:
+              key: client.client_cert
+              name: 3scale-istio-adapter-conf
+        - name: CLIENT_KEY
+          valueFrom:
+            configMapKeyRef:
+              key: client.client_key
+              name: 3scale-istio-adapter-conf
         - name: CLIENT_TIMEOUT_SECONDS
           valueFrom:
             configMapKeyRef:

--- a/scripts/deployment.go
+++ b/scripts/deployment.go
@@ -196,6 +196,39 @@ func main() {
 									},
 								},
 								{
+									Name: "ROOT_CA",
+									ValueFrom: &corev1.EnvVarSource{
+										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: configMapName,
+											},
+											Key: "client.root_ca",
+										},
+									},
+								},
+								{
+									Name: "CLIENT_CERT",
+									ValueFrom: &corev1.EnvVarSource{
+										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: configMapName,
+											},
+											Key: "client.client_cert",
+										},
+									},
+								},
+								{
+									Name: "CLIENT_KEY",
+									ValueFrom: &corev1.EnvVarSource{
+										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: configMapName,
+											},
+											Key: "client.client_key",
+										},
+									},
+								},
+								{
 									Name: "CLIENT_TIMEOUT_SECONDS",
 									ValueFrom: &corev1.EnvVarSource{
 										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{


### PR DESCRIPTION
This adds support for specifying a custom root CA to use when contacting the 3scale service (both system & backend).

Closes #180.