### PR TITLE
Enable ppc64le in 3scale-istio-adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+sudo: false
+dist: bionic
+arch: ppc64le
+include:
+- os: linux
+  addons:
+    packages:
+    - 1.11.x
+    - gcc
+    - make
+
+before_install:
+  - ./ci/setup_${TRAVIS_OS_NAME}_environment.sh
+
+script:
+  - dep ensure -v
+  - make build-adapter build-cli
+  - make unit
+  - make integration

--- a/ci/setup_linux_environment.sh
+++ b/ci/setup_linux_environment.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+###
+# Update PATH Variables
+###
+
+export GOPATH=$HOME/gopath/
+export ISTIO=$GOPATH/src/istio.io/
+mkdir -p $GOPATH/bin
+export PATH=$PATH:$GOPATH/bin/
+
+
+###
+# Install & Setup Golang dep
+###
+
+curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh


### PR DESCRIPTION
This PR fixes issue #184 
For every PR, an equivalent Travis job is triggered for ppc64le architecture.

Signed-off-by: Krishna Harsha Voora <krishvoor@in.ibm.com>