### PR TITLE
Fix OIDC apps requiring an app_key with the client_secret value

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,7 @@
   version = "v0.33.0"
 
 [[projects]]
-  digest = "1:1e379ae2a1796d8bdbeb58fba4d0208aaff91259e0d6c497f4224e615300a24f"
+  digest = "1:5eef56811adbbe21b9cdefbcc334dc24f9dca5713c10b0d6cc49674e092983e0"
   name = "github.com/3scale/3scale-authorizer"
   packages = [
     "pkg/authorizer",
@@ -19,11 +19,11 @@
     "pkg/system/v1/cache",
   ]
   pruneopts = "NUT"
-  revision = "a39078bbbf8ff4158c47daafc41052eb1bb92e9e"
-  version = "v0.0.1"
+  revision = "f7c65e0d7916e44148fb3baf089b1715100c57c2"
+  version = "v0.0.2"
 
 [[projects]]
-  digest = "1:785026af48559cb96056b851f6c0e5776788c2aa36747c84fbe5ca3af7f1b39e"
+  digest = "1:e5118d5039ceec08e3f8e8632c9bf841822c864466b4139f9118664ab6486c23"
   name = "github.com/3scale/3scale-go-client"
   packages = [
     "threescale",
@@ -32,8 +32,8 @@
     "threescale/internal",
   ]
   pruneopts = "NUT"
-  revision = "59f1bbdf5147f20e8e04e81d8d60b7dc196e877f"
-  version = "v0.5.0"
+  revision = "b7a437245b138ed9ef7c35f3c062e5ffb345d47c"
+  version = "v0.5.1"
 
 [[projects]]
   digest = "1:31d9683d91cbf694732a2501bee1c31653b7fe9505812d16c08ccead8d7792c3"
@@ -337,6 +337,14 @@
   pruneopts = "NUT"
   revision = "a96e63847dc3c67d17befa69c303767e2f84e54f"
   version = "v2.1"
+
+[[projects]]
+  digest = "1:a00835b7324a3a40ce1218811a6693cdd7fd75f393b5b273adbb9bbf3bd5341e"
+  name = "github.com/oleiade/lane"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "9fa23cc22f31d14f45d012b1374df3ce247f4767"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:7da29c22bcc5c2ffb308324377dc00b5084650348c2799e573ed226d8cc9faf0"
@@ -752,14 +760,6 @@
   pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
-
-[[projects]]
-  digest = "1:a00835b7324a3a40ce1218811a6693cdd7fd75f393b5b273adbb9bbf3bd5341e"
-  name = "gopkg.in/oleiade/lane.v1"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "28f7c3f09254f12b51e620fa4db136ba58804762"
-  version = "v1.0.0"
 
 [[projects]]
   digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,7 +28,7 @@ required = ["github.com/golang/glog"]
 
 [[constraint]]
   name = "github.com/3scale/3scale-go-client"
-  version = "0.5.0"
+  version = "0.5.1"
 
 [[constraint]]
   name = "github.com/3scale/3scale-porta-go-client"
@@ -36,7 +36,7 @@ required = ["github.com/golang/glog"]
 
 [[constraint]]
   name = "github.com/3scale/3scale-authorizer"
-  version = "0.0.1"
+  version = "0.0.2"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ build-cli: 3scale-config-gen ## Alias to build the config generator cli
 unit: export GO111MODULE ?= auto
 unit: ## Run unit tests
 	mkdir -p "$(PROJECT_PATH)/_output"
-	go test ./... -covermode=count -test.coverprofile="$(PROJECT_PATH)/_output/unit.cov"
+	go test ./... -covermode=count -test.v -test.coverprofile="$(PROJECT_PATH)/_output/unit.cov"
 
 .PHONY: integration
 integration: export GO111MODULE ?= auto
 integration: ## Run integration tests
-	go test -covermode=count -tags integration -test.coverprofile="$(PROJECT_PATH)/_output/integration.cov" -run=TestAuthorizationCheck ./...
+	go test -covermode=count -tags integration -test.v -test.coverprofile="$(PROJECT_PATH)/_output/integration.cov" -run=TestAuthorizationCheck ./...
 
 .PHONY: test
 test: unit integration ## Runs all tests

--- a/pkg/threescale/threescale.go
+++ b/pkg/threescale/threescale.go
@@ -97,7 +97,13 @@ func (s *Threescale) HandleAuthorization(ctx context.Context, r *authorization.H
 		cfg.BackendUrl = proxyConf.Content.Proxy.Backend.Endpoint
 	}
 
-	authResult, err := s.conf.Authorizer.AuthRep(cfg.BackendUrl, backendReq)
+	var authResult *authorizer.BackendResponse
+
+	if proxyConf.Content.BackendVersion == openIDTypeIdentifier {
+		authResult, err = s.conf.Authorizer.OauthAuthRep(cfg.BackendUrl, backendReq)
+	} else {
+		authResult, err = s.conf.Authorizer.AuthRep(cfg.BackendUrl, backendReq)
+	}
 	return s.convertAuthResponse(authResult, result, err)
 }
 

--- a/pkg/threescale/threescale.go
+++ b/pkg/threescale/threescale.go
@@ -100,8 +100,10 @@ func (s *Threescale) HandleAuthorization(ctx context.Context, r *authorization.H
 	var authResult *authorizer.BackendResponse
 
 	if proxyConf.Content.BackendVersion == openIDTypeIdentifier {
+	        log.Debugf("HandleAuthorization: backend_version is %#v, calling OauthAuthRep\n", proxyConf.Content.BackendVersion)
 		authResult, err = s.conf.Authorizer.OauthAuthRep(cfg.BackendUrl, backendReq)
 	} else {
+	        log.Debugf("HandleAuthorization: backend_version is %#v, calling AuthRep\n", proxyConf.Content.BackendVersion)
 		authResult, err = s.conf.Authorizer.AuthRep(cfg.BackendUrl, backendReq)
 	}
 	return s.convertAuthResponse(authResult, result, err)

--- a/pkg/threescale/threescale_test.go
+++ b/pkg/threescale/threescale_test.go
@@ -280,6 +280,10 @@ func (m mockAuthorizer) GetSystemConfiguration(systemURL string, request authori
 	return m.withConfig, m.withSystemErr
 }
 
+func (m mockAuthorizer) OauthAuthRep(backendURL string, request authorizer.BackendRequest) (*authorizer.BackendResponse, error) {
+	return m.AuthRep(backendURL, request)
+}
+
 func (m mockAuthorizer) AuthRep(backendURL string, request authorizer.BackendRequest) (*authorizer.BackendResponse, error) {
 	if m.withAuthRepCallback != nil {
 		m.withAuthRepCallback(backendURL, request, m.t)

--- a/pkg/threescale/types.go
+++ b/pkg/threescale/types.go
@@ -27,6 +27,7 @@ type Threescale struct {
 type Authorizer interface {
 	GetSystemConfiguration(systemURL string, request authorizer.SystemRequest) (client.ProxyConfig, error)
 	AuthRep(backendURL string, request authorizer.BackendRequest) (*authorizer.BackendResponse, error)
+	OauthAuthRep(backendURL string, request authorizer.BackendRequest) (*authorizer.BackendResponse, error)
 	Shutdown()
 }
 


### PR DESCRIPTION
This PR stops the requirement in past releases of the Adapter for OIDC applications to provide their `client_secret` as the `app_key` parameter to authorize the OIDC flow.

Fixes [THREESCALE-7117](https://issues.redhat.com/browse/THREESCALE-7117) and [OSSM-485](https://issues.redhat.com/browse/OSSM-485) - you can learn more about the details at https://github.com/3scale/apisonator/pull/280.