### PR TITLE
Release 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Notable changes to 3scale Istio Mixer Adapter will be tracked in this document.
 
+## 2.0.3 - 2021-06-14
+
+### Added
+
+- Added CI tests for the ppc64le architecture. ([#185](https://github.com/3scale/3scale-istio-adapter/pull/185))
+
+### Fixed
+
+- No longer require for OIDC flows to provide the application's `client_secret`
+  as the `app_key` parameter. ([#188](https://github.com/3scale/3scale-istio-adapter/pull/188))
+- Go 1.16 compilation. ([#187](https://github.com/3scale/3scale-istio-adapter/pull/187))
+- Fixed a few minor warnings in the code. ([#186](https://github.com/3scale/3scale-istio-adapter/pull/186))
+
 ## 2.0.2 - 2021-03-02
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG ?=  $(shell git -C "$(PROJECT_PATH)" describe --dirty --tags)
+TAG ?= $(shell git -C "$(PROJECT_PATH)" describe --dirty --tags)
 ifdef VERSION
 override TAG = $(VERSION)
 endif
@@ -135,6 +135,7 @@ validate-release:
 	@if [ -z ${VERSION} ]; then echo VERSION is unset && exit 1; fi
 
 .PHONY: generate-template
+generate-template: export GO111MODULE ?= auto
 generate-template:
 	@go run -ldflags="-X main.version=$(VERSION)" "$(PROJECT_PATH)/scripts/deployment.go" > "$(PROJECT_PATH)/deploy/deployment.yaml"
 

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,8 +1,8 @@
-# This code was generated as part of the release process using make release for version v2.0.2
+# This code was generated as part of the release process using make release for version v2.0.3
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: "2021-03-02T16:34:08Z"
+  creationTimestamp: "2021-06-14T18:29:04Z"
   labels:
     app: 3scale-istio-adapter
   name: 3scale-istio-adapter
@@ -18,7 +18,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: "2021-03-02T16:34:08Z"
+      creationTimestamp: "2021-06-14T18:29:04Z"
       labels:
         app: 3scale-istio-adapter
     spec:
@@ -104,7 +104,7 @@ spec:
             configMapKeyRef:
               key: backend.policy_fail_closed
               name: 3scale-istio-adapter-conf
-        image: quay.io/3scale/3scale-istio-adapter:v2.0.2
+        image: quay.io/3scale/3scale-istio-adapter:v2.0.3
         imagePullPolicy: Always
         livenessProbe:
           initialDelaySeconds: 10


### PR DESCRIPTION
This release includes a fix for OIDC to no longer require `app_key=<client_secret>`.